### PR TITLE
Implement i18n / localization system

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,194 @@
+// ============================================================
+// Teryx — Internationalization (i18n)
+// ============================================================
+
+/** Locale strings organised by widget / category. */
+export interface TeryxLocale {
+  grid: {
+    search: string;
+    noData: string;
+    showing: string;
+    page: string;
+    of: string;
+    filter: string;
+    all: string;
+    yes: string;
+    no: string;
+    columns: string;
+    export: string;
+  };
+  pagination: {
+    first: string;
+    last: string;
+    previous: string;
+    next: string;
+    page: string;
+    of: string;
+    rowsPerPage: string;
+    jumpTo: string;
+  };
+  form: {
+    submit: string;
+    cancel: string;
+    required: string;
+    invalidValue: string;
+  };
+  upload: {
+    browse: string;
+    dropText: string;
+    maxFileSize: string;
+    maxFilesExceeded: string;
+    uploaded: string;
+    failed: string;
+  };
+  calendar: {
+    today: string;
+    month: string;
+    week: string;
+    day: string;
+    agenda: string;
+  };
+  toast: {
+    close: string;
+  };
+  general: {
+    loading: string;
+    noResults: string;
+    confirm: string;
+    cancel: string;
+    ok: string;
+    save: string;
+    delete: string;
+    edit: string;
+    search: string;
+    clear: string;
+  };
+}
+
+/** Default English locale. */
+const defaultLocale: TeryxLocale = {
+  grid: {
+    search: 'Search...',
+    noData: 'No data found',
+    showing: 'Showing',
+    page: 'Page',
+    of: 'of',
+    filter: 'Filter...',
+    all: 'All',
+    yes: 'Yes',
+    no: 'No',
+    columns: 'Columns',
+    export: 'Export',
+  },
+  pagination: {
+    first: 'First',
+    last: 'Last',
+    previous: 'Previous',
+    next: 'Next',
+    page: 'Page',
+    of: 'of',
+    rowsPerPage: 'Rows per page',
+    jumpTo: 'Jump to',
+  },
+  form: {
+    submit: 'Submit',
+    cancel: 'Cancel',
+    required: 'This field is required',
+    invalidValue: 'Invalid value',
+  },
+  upload: {
+    browse: 'Browse',
+    dropText: 'Drop files here or ',
+    maxFileSize: 'Max file size:',
+    maxFilesExceeded: 'Maximum {n} files allowed',
+    uploaded: 'Uploaded',
+    failed: 'Failed',
+  },
+  calendar: {
+    today: 'Today',
+    month: 'Month',
+    week: 'Week',
+    day: 'Day',
+    agenda: 'Agenda',
+  },
+  toast: {
+    close: 'Close',
+  },
+  general: {
+    loading: 'Loading...',
+    noResults: 'No results',
+    confirm: 'Confirm',
+    cancel: 'Cancel',
+    ok: 'OK',
+    save: 'Save',
+    delete: 'Delete',
+    edit: 'Edit',
+    search: 'Search',
+    clear: 'Clear',
+  },
+};
+
+// The active locale (mutable copy of default).
+let currentLocale: TeryxLocale = deepClone(defaultLocale);
+
+// ----------------------------------------------------------
+//  Helpers
+// ----------------------------------------------------------
+
+function deepClone<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+/** Deep-merge `source` into `target`, mutating target. */
+function deepMerge<T extends Record<string, unknown>>(target: T, source: Partial<T>): T {
+  for (const key of Object.keys(source) as (keyof T)[]) {
+    const sv = source[key];
+    const tv = target[key];
+    if (sv && typeof sv === 'object' && !Array.isArray(sv) && tv && typeof tv === 'object' && !Array.isArray(tv)) {
+      deepMerge(tv as Record<string, unknown>, sv as Record<string, unknown>);
+    } else if (sv !== undefined) {
+      (target as Record<string, unknown>)[key as string] = sv;
+    }
+  }
+  return target;
+}
+
+// ----------------------------------------------------------
+//  Public API
+// ----------------------------------------------------------
+
+/**
+ * Replace or partially override the active locale.
+ * Values are deep-merged so you only need to supply the keys you want to change.
+ */
+export function setLocale(locale: Partial<TeryxLocale>): void {
+  deepMerge(currentLocale as unknown as Record<string, unknown>, locale as unknown as Record<string, unknown>);
+}
+
+/** Return the full active locale object. */
+export function getLocale(): TeryxLocale {
+  return currentLocale;
+}
+
+/**
+ * Resolve a dot-separated path to a locale string.
+ *
+ * @example t('grid.search') // => 'Search...'
+ */
+export function t(path: string): string {
+  const parts = path.split('.');
+  let node: unknown = currentLocale;
+  for (const part of parts) {
+    if (node && typeof node === 'object') {
+      node = (node as Record<string, unknown>)[part];
+    } else {
+      return path; // fallback to path itself
+    }
+  }
+  return typeof node === 'string' ? node : path;
+}
+
+/** Reset the locale back to the built-in English defaults. */
+export function resetLocale(): void {
+  currentLocale = deepClone(defaultLocale);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ export { configure, config, initWidgets, registerWidget, on, off, emit } from '.
 // Types
 export type * from './types';
 
+// i18n
+export { setLocale, getLocale, t } from './i18n';
+export type { TeryxLocale } from './i18n';
+
 // Utilities
 export { uid, esc, cls, icon, icons, resolveTarget, createElement, debounce, throttle, clamp } from './utils';
 

--- a/src/widgets/fileupload.ts
+++ b/src/widgets/fileupload.ts
@@ -5,6 +5,7 @@
 import type { FileUploadOptions, WidgetInstance } from '../types';
 import { uid, esc, cls, icon, resolveTarget } from '../utils';
 import { registerWidget, emit } from '../core';
+import { t } from '../i18n';
 
 export function fileupload(target: string | HTMLElement, options: FileUploadOptions): WidgetInstance {
   const el = resolveTarget(target);
@@ -22,10 +23,10 @@ export function fileupload(target: string | HTMLElement, options: FileUploadOpti
   html += `<div class="tx-upload-icon">${icon('upload', 32)}</div>`;
   html += '<div class="tx-upload-text">';
   if (dragDrop) {
-    html += '<span>Drop files here or </span>';
+    html += `<span>${esc(t('upload.dropText'))}</span>`;
   }
   html += `<label class="tx-upload-browse">`;
-  html += 'Browse';
+  html += esc(t('upload.browse'));
   html += `<input type="file" class="tx-upload-input"`;
   if (multiple) html += ' multiple';
   if (options.accept) html += ` accept="${esc(options.accept)}"`;

--- a/src/widgets/form.ts
+++ b/src/widgets/form.ts
@@ -5,6 +5,7 @@
 import type { FormOptions, FormField, FormInstance, SelectOption } from '../types';
 import { uid, esc, cls, icon, resolveTarget } from '../utils';
 import { registerWidget, emit } from '../core';
+import { t } from '../i18n';
 
 export function form(target: string | HTMLElement, options: FormOptions): FormInstance {
   const el = resolveTarget(target);
@@ -48,9 +49,9 @@ export function form(target: string | HTMLElement, options: FormOptions): FormIn
   html += '<div class="tx-form-actions">';
   html += `<button type="submit" class="tx-btn tx-btn-primary"`;
   if (options.indicator) html += ` xh-indicator="${esc(options.indicator)}"`;
-  html += `>${esc(options.submitLabel || 'Submit')}</button>`;
-  if (options.cancelLabel) {
-    html += `<button type="button" class="tx-btn tx-btn-secondary tx-form-cancel">${esc(options.cancelLabel)}</button>`;
+  html += `>${esc(options.submitLabel || t('form.submit'))}</button>`;
+  if (options.cancelLabel !== undefined) {
+    html += `<button type="button" class="tx-btn tx-btn-secondary tx-form-cancel">${esc(options.cancelLabel || t('form.cancel'))}</button>`;
   }
   html += '</div>';
 

--- a/src/widgets/grid.ts
+++ b/src/widgets/grid.ts
@@ -5,6 +5,7 @@
 import type { GridOptions, GridColumn, GridInstance, ToolbarItem } from '../types';
 import { uid, esc, cls, icon, resolveTarget } from '../utils';
 import { registerWidget } from '../core';
+import { t } from '../i18n';
 
 export function grid(target: string | HTMLElement, options: GridOptions): GridInstance {
   const el = resolveTarget(target);
@@ -128,7 +129,7 @@ function renderToolbar(options: GridOptions, id: string): string {
     html += `<span class="tx-input-icon">${icon('search')}</span>`;
     html += `<input type="text" id="${esc(id)}-search"`;
     html += ` class="tx-input tx-grid-search"`;
-    html += ` placeholder="Search..."`;
+    html += ` placeholder="${esc(t('grid.search'))}"`;
     html += ` name="${esc(options.searchParam || 'q')}">`;
     html += `</div>`;
   }
@@ -310,7 +311,7 @@ function renderTableTemplate(
   // Empty state
   html += `<div xh-if="!${esc(rowsField)}.length" class="tx-grid-empty">`;
   html += `<div class="tx-grid-empty-icon">${icon('file')}</div>`;
-  html += `<div class="tx-grid-empty-text">${esc(options.emptyMessage || 'No data found')}</div>`;
+  html += `<div class="tx-grid-empty-text">${esc(options.emptyMessage || t('grid.noData'))}</div>`;
   html += '</div>';
 
   // Pagination

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { setLocale, getLocale, t, resetLocale } from '../src/i18n';
+
+describe('i18n', () => {
+  afterEach(() => {
+    resetLocale();
+  });
+
+  // ---- t() ----
+  it('should resolve a dot-path to the default English string', () => {
+    expect(t('grid.search')).toBe('Search...');
+  });
+
+  it('should return the path string when the key does not exist', () => {
+    expect(t('nonexistent.key')).toBe('nonexistent.key');
+  });
+
+  it('should resolve deeply nested paths', () => {
+    expect(t('form.submit')).toBe('Submit');
+    expect(t('form.cancel')).toBe('Cancel');
+  });
+
+  // ---- getLocale() ----
+  it('should return the full locale object', () => {
+    const locale = getLocale();
+    expect(locale.grid).toBeDefined();
+    expect(locale.form).toBeDefined();
+    expect(locale.upload).toBeDefined();
+    expect(locale.calendar).toBeDefined();
+    expect(locale.toast).toBeDefined();
+    expect(locale.general).toBeDefined();
+    expect(locale.pagination).toBeDefined();
+  });
+
+  // ---- setLocale() partial merge ----
+  it('should deep-merge a partial locale without overwriting other keys', () => {
+    setLocale({
+      grid: {
+        search: 'Suchen...',
+        noData: 'Keine Daten',
+        showing: '',
+        page: '',
+        of: '',
+        filter: '',
+        all: '',
+        yes: '',
+        no: '',
+        columns: '',
+        export: '',
+      },
+    });
+    expect(t('grid.search')).toBe('Suchen...');
+    // Other top-level groups are untouched
+    expect(t('form.submit')).toBe('Submit');
+  });
+
+  it('should allow overriding a single nested value via setLocale', () => {
+    setLocale({ form: { submit: 'Envoyer', cancel: 'Cancel', required: '', invalidValue: '' } });
+    expect(t('form.submit')).toBe('Envoyer');
+    expect(t('form.cancel')).toBe('Cancel');
+  });
+
+  // ---- resetLocale() ----
+  it('should restore defaults after resetLocale()', () => {
+    setLocale({
+      grid: {
+        search: 'Buscar...',
+        noData: '',
+        showing: '',
+        page: '',
+        of: '',
+        filter: '',
+        all: '',
+        yes: '',
+        no: '',
+        columns: '',
+        export: '',
+      },
+    });
+    expect(t('grid.search')).toBe('Buscar...');
+    resetLocale();
+    expect(t('grid.search')).toBe('Search...');
+  });
+
+  // ---- edge cases ----
+  it('should return path when resolving into a non-object segment', () => {
+    // 'grid.search' is a string; asking for 'grid.search.deeper' should fallback
+    expect(t('grid.search.deeper')).toBe('grid.search.deeper');
+  });
+
+  it('should handle an empty path by returning an empty string as path', () => {
+    expect(t('')).toBe('');
+  });
+
+  // ---- default locale completeness ----
+  it('should contain all expected default English strings', () => {
+    expect(t('grid.noData')).toBe('No data found');
+    expect(t('upload.browse')).toBe('Browse');
+    expect(t('upload.dropText')).toBe('Drop files here or ');
+    expect(t('general.loading')).toBe('Loading...');
+    expect(t('toast.close')).toBe('Close');
+    expect(t('calendar.today')).toBe('Today');
+    expect(t('pagination.next')).toBe('Next');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/i18n.ts` with `TeryxLocale` interface, default English locale, `setLocale()`, `getLocale()`, `t()`, and `resetLocale()` APIs
- Update `grid.ts` to use `t('grid.search')` for search placeholder and `t('grid.noData')` for empty message
- Update `form.ts` to use `t('form.submit')` and `t('form.cancel')` for default button labels
- Update `fileupload.ts` to use `t('upload.browse')` and `t('upload.dropText')` for default strings
- Export `setLocale`, `getLocale`, `t`, and `TeryxLocale` from `src/index.ts`

## Test plan
- [x] typecheck passes
- [x] unit tests pass (10 new i18n tests, 362 total)

Closes #25