### PR TITLE
Implement theme switcher

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,10 @@ export type * from './types';
 export { setLocale, getLocale, t } from './i18n';
 export type { TeryxLocale } from './i18n';
 
+// Theme
+export { setTheme, getTheme, registerTheme, getThemeNames } from './theme';
+export type { TeryxTheme } from './theme';
+
 // Utilities
 export { uid, esc, cls, icon, icons, resolveTarget, createElement, debounce, throttle, clamp } from './utils';
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,139 @@
+// ============================================================
+// Teryx — Theme Switcher
+// ============================================================
+
+/** A named set of CSS custom-property overrides. */
+export interface TeryxTheme {
+  name: string;
+  vars: Record<string, string>;
+}
+
+// ----------------------------------------------------------
+//  Built-in themes
+// ----------------------------------------------------------
+
+const lightTheme: TeryxTheme = {
+  name: 'light',
+  vars: {
+    '--tx-bg': '#ffffff',
+    '--tx-bg-secondary': '#f9fafb',
+    '--tx-bg-tertiary': '#f3f4f6',
+    '--tx-bg-elevated': '#ffffff',
+    '--tx-surface': '#ffffff',
+    '--tx-overlay': 'rgba(0, 0, 0, 0.5)',
+    '--tx-text': '#111827',
+    '--tx-text-secondary': '#6b7280',
+    '--tx-text-muted': '#9ca3af',
+    '--tx-text-inverse': '#ffffff',
+    '--tx-border': '#e5e7eb',
+    '--tx-border-strong': '#d1d5db',
+    '--tx-shadow-sm': '0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06)',
+    '--tx-shadow': '0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.06)',
+    '--tx-shadow-lg': '0 10px 15px rgba(0,0,0,0.1), 0 4px 6px rgba(0,0,0,0.05)',
+  },
+};
+
+const darkTheme: TeryxTheme = {
+  name: 'dark',
+  vars: {
+    '--tx-bg': '#111827',
+    '--tx-bg-secondary': '#1f2937',
+    '--tx-bg-tertiary': '#374151',
+    '--tx-bg-elevated': '#1f2937',
+    '--tx-surface': '#1f2937',
+    '--tx-overlay': 'rgba(0, 0, 0, 0.7)',
+    '--tx-text': '#f9fafb',
+    '--tx-text-secondary': '#d1d5db',
+    '--tx-text-muted': '#9ca3af',
+    '--tx-text-inverse': '#111827',
+    '--tx-border': '#374151',
+    '--tx-border-strong': '#4b5563',
+    '--tx-shadow-sm': '0 1px 3px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2)',
+    '--tx-shadow': '0 4px 6px rgba(0,0,0,0.3), 0 2px 4px rgba(0,0,0,0.2)',
+    '--tx-shadow-lg': '0 10px 15px rgba(0,0,0,0.4), 0 4px 6px rgba(0,0,0,0.2)',
+  },
+};
+
+const highContrastTheme: TeryxTheme = {
+  name: 'highContrast',
+  vars: {
+    '--tx-bg': '#000000',
+    '--tx-bg-secondary': '#1a1a1a',
+    '--tx-bg-tertiary': '#2d2d2d',
+    '--tx-bg-elevated': '#1a1a1a',
+    '--tx-surface': '#1a1a1a',
+    '--tx-overlay': 'rgba(0, 0, 0, 0.85)',
+    '--tx-text': '#ffffff',
+    '--tx-text-secondary': '#e5e5e5',
+    '--tx-text-muted': '#cccccc',
+    '--tx-text-inverse': '#000000',
+    '--tx-border': '#ffffff',
+    '--tx-border-strong': '#ffffff',
+    '--tx-primary': '#3b9aff',
+    '--tx-primary-hover': '#69b3ff',
+    '--tx-success': '#22d68e',
+    '--tx-warning': '#fbbf24',
+    '--tx-danger': '#ff6b6b',
+    '--tx-shadow-sm': '0 0 0 1px rgba(255,255,255,0.3)',
+    '--tx-shadow': '0 0 0 1px rgba(255,255,255,0.3)',
+    '--tx-shadow-lg': '0 0 0 2px rgba(255,255,255,0.4)',
+  },
+};
+
+// ----------------------------------------------------------
+//  Registry & state
+// ----------------------------------------------------------
+
+const themes = new Map<string, TeryxTheme>();
+let currentThemeName = 'light';
+
+// Register built-in themes
+themes.set('light', lightTheme);
+themes.set('dark', darkTheme);
+themes.set('highContrast', highContrastTheme);
+
+// ----------------------------------------------------------
+//  Public API
+// ----------------------------------------------------------
+
+/**
+ * Apply a registered theme by name.
+ * Sets CSS variables on `document.documentElement` and a `data-theme` attribute.
+ *
+ * @throws If the theme name has not been registered.
+ */
+export function setTheme(name: string): void {
+  const theme = themes.get(name);
+  if (!theme) {
+    throw new Error(`Teryx: unknown theme "${name}". Register it first via registerTheme().`);
+  }
+
+  // Apply CSS custom properties
+  if (typeof document !== 'undefined') {
+    const root = document.documentElement;
+    for (const [prop, value] of Object.entries(theme.vars)) {
+      root.style.setProperty(prop, value);
+    }
+    root.setAttribute('data-theme', name);
+  }
+
+  currentThemeName = name;
+}
+
+/** Return the name of the currently active theme. */
+export function getTheme(): string {
+  return currentThemeName;
+}
+
+/**
+ * Register a custom theme (or replace an existing one).
+ * Does **not** activate the theme — call `setTheme(theme.name)` afterwards.
+ */
+export function registerTheme(theme: TeryxTheme): void {
+  themes.set(theme.name, theme);
+}
+
+/** Return the names of all registered themes. */
+export function getThemeNames(): string[] {
+  return Array.from(themes.keys());
+}

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setTheme, getTheme, registerTheme, getThemeNames } from '../src/theme';
+
+describe('theme', () => {
+  beforeEach(() => {
+    // Reset to light theme before each test
+    setTheme('light');
+    // Clean up any inline styles left by previous tests
+    document.documentElement.removeAttribute('style');
+    document.documentElement.removeAttribute('data-theme');
+    setTheme('light');
+  });
+
+  // ---- getThemeNames() ----
+  it('should include the three built-in themes', () => {
+    const names = getThemeNames();
+    expect(names).toContain('light');
+    expect(names).toContain('dark');
+    expect(names).toContain('highContrast');
+  });
+
+  // ---- getTheme() / setTheme() ----
+  it('should default to "light" theme', () => {
+    expect(getTheme()).toBe('light');
+  });
+
+  it('should switch to dark theme and update data-theme attribute', () => {
+    setTheme('dark');
+    expect(getTheme()).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('should apply CSS variables when switching themes', () => {
+    setTheme('dark');
+    const bg = document.documentElement.style.getPropertyValue('--tx-bg');
+    expect(bg).toBe('#111827');
+  });
+
+  it('should throw when setting an unregistered theme', () => {
+    expect(() => setTheme('nonexistent')).toThrow('unknown theme "nonexistent"');
+  });
+
+  // ---- registerTheme() ----
+  it('should register a custom theme and allow switching to it', () => {
+    registerTheme({
+      name: 'ocean',
+      vars: {
+        '--tx-bg': '#0a1628',
+        '--tx-text': '#e0f0ff',
+      },
+    });
+    expect(getThemeNames()).toContain('ocean');
+
+    setTheme('ocean');
+    expect(getTheme()).toBe('ocean');
+    expect(document.documentElement.style.getPropertyValue('--tx-bg')).toBe('#0a1628');
+  });
+
+  it('should allow replacing an existing built-in theme', () => {
+    registerTheme({
+      name: 'light',
+      vars: {
+        '--tx-bg': '#fefefe',
+      },
+    });
+    setTheme('light');
+    expect(document.documentElement.style.getPropertyValue('--tx-bg')).toBe('#fefefe');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/theme.ts` with `TeryxTheme` interface and three built-in themes: `light`, `dark`, `highContrast`
- `setTheme(name)` applies CSS custom properties to `document.documentElement` and sets `data-theme` attribute
- `getTheme()` returns current active theme name
- `registerTheme(theme)` allows registering custom themes
- `getThemeNames()` lists all registered theme names
- Export all theme functions and `TeryxTheme` type from `src/index.ts`

## Test plan
- [x] typecheck passes
- [x] unit tests pass (7 new theme tests, 359 total)

Closes #26