### PR TITLE
Implement client-side router

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ export type { TeryxLocale } from './i18n';
 export { setTheme, getTheme, registerTheme, getThemeNames } from './theme';
 export type { TeryxTheme } from './theme';
 
+// Router
+export { createRouter } from './router';
+export type { Route, RouterOptions, Router } from './router';
+
 // Utilities
 export { uid, esc, cls, icon, icons, resolveTarget, createElement, debounce, throttle, clamp } from './utils';
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,191 @@
+// ============================================================
+// Teryx — Client-side Router
+// ============================================================
+
+/** A single route definition. */
+export interface Route {
+  /** URL path pattern, supports `:param` segments (e.g. `/users/:id`). */
+  path: string;
+  /** Handler invoked when the route matches. */
+  handler: (params: Record<string, string>) => void;
+  /** Optional guard — return `false` to block navigation. */
+  guard?: (params: Record<string, string>) => boolean;
+}
+
+/** Options for creating a router. */
+export interface RouterOptions {
+  /** Routing mode: `'hash'` (default) uses `#/path`, `'history'` uses pushState. */
+  mode?: 'hash' | 'history';
+  /** Base path prepended in history mode (default `''`). */
+  base?: string;
+  /** Handler invoked when no route matches. */
+  notFound?: (path: string) => void;
+}
+
+/** The router instance returned by `createRouter()`. */
+export interface Router {
+  /** Register a route. */
+  route(
+    path: string,
+    handler: (params: Record<string, string>) => void,
+    guard?: (params: Record<string, string>) => boolean,
+  ): Router;
+  /** Navigate to a path programmatically. */
+  navigate(path: string): void;
+  /** Return the current path. */
+  current(): string;
+  /** Start listening for URL changes. */
+  start(): void;
+  /** Stop listening for URL changes. */
+  stop(): void;
+  /** Navigate back in browser history. */
+  back(): void;
+}
+
+// ----------------------------------------------------------
+//  Internal helpers
+// ----------------------------------------------------------
+
+interface CompiledRoute {
+  route: Route;
+  regex: RegExp;
+  paramNames: string[];
+}
+
+/**
+ * Compile a path pattern like `/users/:id/posts/:postId` into a regex
+ * and extract param names.
+ */
+export function compilePath(path: string): { regex: RegExp; paramNames: string[] } {
+  const paramNames: string[] = [];
+  const regexStr = path
+    .replace(/:[a-zA-Z_][a-zA-Z0-9_]*/g, (match) => {
+      paramNames.push(match.slice(1));
+      return '([^/]+)';
+    })
+    // Escape forward slashes for regex
+    .replace(/\//g, '\\/');
+  return { regex: new RegExp(`^${regexStr}$`), paramNames };
+}
+
+/**
+ * Try to match a path against a compiled route.
+ * Returns the extracted params or `null` if no match.
+ */
+export function matchRoute(compiledRoute: CompiledRoute, path: string): Record<string, string> | null {
+  const match = path.match(compiledRoute.regex);
+  if (!match) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < compiledRoute.paramNames.length; i++) {
+    params[compiledRoute.paramNames[i]] = decodeURIComponent(match[i + 1]);
+  }
+  return params;
+}
+
+// ----------------------------------------------------------
+//  Public API
+// ----------------------------------------------------------
+
+/** Create a new router instance. */
+export function createRouter(opts?: RouterOptions): Router {
+  const mode = opts?.mode ?? 'hash';
+  const base = (opts?.base ?? '').replace(/\/$/, '');
+  const notFound = opts?.notFound;
+
+  const routes: CompiledRoute[] = [];
+  let listening = false;
+  let listener: (() => void) | null = null;
+
+  function currentPath(): string {
+    if (mode === 'hash') {
+      const hash = typeof window !== 'undefined' ? window.location.hash : '';
+      return hash.replace(/^#\/?/, '/').replace(/^$/, '/');
+    }
+    const pathname = typeof window !== 'undefined' ? window.location.pathname : '/';
+    return base ? pathname.replace(new RegExp(`^${base}`), '') || '/' : pathname;
+  }
+
+  function resolve(path: string): void {
+    const normalised = path.startsWith('/') ? path : `/${path}`;
+    for (const compiled of routes) {
+      const params = matchRoute(compiled, normalised);
+      if (params !== null) {
+        // Check guard
+        if (compiled.route.guard && !compiled.route.guard(params)) {
+          return;
+        }
+        compiled.route.handler(params);
+        return;
+      }
+    }
+    // No match
+    notFound?.(normalised);
+  }
+
+  const router: Router = {
+    route(path, handler, guard?) {
+      const { regex, paramNames } = compilePath(path);
+      routes.push({ route: { path, handler, guard }, regex, paramNames });
+      return router;
+    },
+
+    navigate(path: string) {
+      const normalised = path.startsWith('/') ? path : `/${path}`;
+      if (typeof window !== 'undefined') {
+        if (mode === 'hash') {
+          window.location.hash = `#${normalised}`;
+          // hashchange event will call resolve
+        } else {
+          window.history.pushState(null, '', `${base}${normalised}`);
+          resolve(normalised);
+        }
+      }
+    },
+
+    current() {
+      return currentPath();
+    },
+
+    start() {
+      if (listening) return;
+      listening = true;
+
+      if (mode === 'hash') {
+        listener = () => resolve(currentPath());
+        if (typeof window !== 'undefined') {
+          window.addEventListener('hashchange', listener);
+        }
+      } else {
+        listener = () => resolve(currentPath());
+        if (typeof window !== 'undefined') {
+          window.addEventListener('popstate', listener);
+        }
+      }
+
+      // Resolve the current path immediately
+      resolve(currentPath());
+    },
+
+    stop() {
+      if (!listening || !listener) return;
+      listening = false;
+      if (typeof window !== 'undefined') {
+        if (mode === 'hash') {
+          window.removeEventListener('hashchange', listener);
+        } else {
+          window.removeEventListener('popstate', listener);
+        }
+      }
+      listener = null;
+    },
+
+    back() {
+      if (typeof window !== 'undefined') {
+        window.history.back();
+      }
+    },
+  };
+
+  return router;
+}

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRouter, compilePath, matchRoute } from '../src/router';
+
+// ----------------------------------------------------------
+//  compilePath / matchRoute (pure logic, no DOM)
+// ----------------------------------------------------------
+describe('compilePath', () => {
+  it('should compile a static path', () => {
+    const { regex, paramNames } = compilePath('/about');
+    expect(paramNames).toEqual([]);
+    expect(regex.test('/about')).toBe(true);
+    expect(regex.test('/other')).toBe(false);
+  });
+
+  it('should compile a path with one param', () => {
+    const { regex, paramNames } = compilePath('/users/:id');
+    expect(paramNames).toEqual(['id']);
+    expect(regex.test('/users/42')).toBe(true);
+    expect(regex.test('/users/')).toBe(false);
+    expect(regex.test('/users')).toBe(false);
+  });
+
+  it('should compile a path with multiple params', () => {
+    const { regex, paramNames } = compilePath('/users/:userId/posts/:postId');
+    expect(paramNames).toEqual(['userId', 'postId']);
+    expect(regex.test('/users/1/posts/99')).toBe(true);
+    expect(regex.test('/users/1/posts')).toBe(false);
+  });
+});
+
+describe('matchRoute', () => {
+  it('should extract params from a matching path', () => {
+    const { regex, paramNames } = compilePath('/users/:id');
+    const compiled = { route: { path: '/users/:id', handler: () => {} }, regex, paramNames };
+    const params = matchRoute(compiled, '/users/42');
+    expect(params).toEqual({ id: '42' });
+  });
+
+  it('should return null for a non-matching path', () => {
+    const { regex, paramNames } = compilePath('/users/:id');
+    const compiled = { route: { path: '/users/:id', handler: () => {} }, regex, paramNames };
+    expect(matchRoute(compiled, '/posts/1')).toBeNull();
+  });
+
+  it('should decode URI-encoded param values', () => {
+    const { regex, paramNames } = compilePath('/search/:query');
+    const compiled = { route: { path: '/search/:query', handler: () => {} }, regex, paramNames };
+    const params = matchRoute(compiled, '/search/hello%20world');
+    expect(params).toEqual({ query: 'hello world' });
+  });
+});
+
+// ----------------------------------------------------------
+//  createRouter (uses jsdom)
+// ----------------------------------------------------------
+describe('createRouter', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
+  it('should create a router in hash mode by default', () => {
+    const router = createRouter();
+    expect(router).toBeDefined();
+    expect(typeof router.route).toBe('function');
+    expect(typeof router.navigate).toBe('function');
+  });
+
+  it('should call handler when start() resolves the current hash', () => {
+    window.location.hash = '#/dashboard';
+    const handler = vi.fn();
+    const router = createRouter();
+    router.route('/dashboard', handler);
+    router.start();
+    expect(handler).toHaveBeenCalledWith({});
+    router.stop();
+  });
+
+  it('should call notFound when no route matches', () => {
+    window.location.hash = '#/unknown';
+    const notFound = vi.fn();
+    const router = createRouter({ notFound });
+    router.route('/home', () => {});
+    router.start();
+    expect(notFound).toHaveBeenCalledWith('/unknown');
+    router.stop();
+  });
+
+  it('should block navigation when guard returns false', () => {
+    window.location.hash = '#/admin';
+    const handler = vi.fn();
+    const guard = vi.fn(() => false);
+    const router = createRouter();
+    router.route('/admin', handler, guard);
+    router.start();
+    expect(guard).toHaveBeenCalledWith({});
+    expect(handler).not.toHaveBeenCalled();
+    router.stop();
+  });
+
+  it('should allow navigation when guard returns true', () => {
+    window.location.hash = '#/admin';
+    const handler = vi.fn();
+    const guard = vi.fn(() => true);
+    const router = createRouter();
+    router.route('/admin', handler, guard);
+    router.start();
+    expect(guard).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalled();
+    router.stop();
+  });
+
+  it('should support chaining via route()', () => {
+    const router = createRouter();
+    const result = router.route('/a', () => {}).route('/b', () => {});
+    expect(result).toBe(router);
+  });
+
+  it('should return current path via current()', () => {
+    window.location.hash = '#/settings';
+    const router = createRouter();
+    expect(router.current()).toBe('/settings');
+  });
+
+  it('should resolve root path when hash is empty', () => {
+    window.location.hash = '';
+    const handler = vi.fn();
+    const router = createRouter();
+    router.route('/', handler);
+    router.start();
+    expect(handler).toHaveBeenCalledWith({});
+    router.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/router.ts` with `Route`, `RouterOptions`, and `Router` interfaces
- `createRouter(opts?)` creates a router instance supporting hash mode (default) and history mode
- Path matching with `:param` support via regex compilation
- Guards can block navigation by returning `false`
- `router.route()`, `navigate()`, `current()`, `start()`, `stop()`, `back()` APIs
- Export `createRouter` and associated types from `src/index.ts`

## Test plan
- [x] typecheck passes
- [x] unit tests pass (14 new router tests, 366 total)

Closes #27