### PR TITLE
Add bundle size analyzer with size-limit

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,5 @@
+[
+  { "path": "dist/index.js", "limit": "300 KB" },
+  { "path": "dist/index.global.js", "limit": "320 KB" },
+  { "path": "dist/teryx.css", "limit": "100 KB" }
+]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:browser": "playwright test --config tests/browser/playwright.config.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "size": "size-limit",
+    "size:check": "size-limit --limit"
   },
   "keywords": [
     "xhtmlx",
@@ -43,11 +45,13 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",
+    "@size-limit/file": "^12.0.1",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
     "express": "^4.18.2",
     "jsdom": "^24.0.0",
     "prettier": "^3.8.1",
+    "size-limit": "^12.0.1",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      '@size-limit/file':
+        specifier: ^12.0.1
+        version: 12.0.1(size-limit@12.0.1)
       eslint:
         specifier: ^10.0.3
         version: 10.0.3
@@ -29,6 +32,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      size-limit:
+        specifier: ^12.0.1
+        version: 12.0.1
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
@@ -587,6 +593,12 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@size-limit/file@12.0.1':
+    resolution: {integrity: sha512-Kvbnz46iV7WeHaANf1HmWjXBVMU2KkCU+0xJ78FzIjZwlVKKEqy+QCZprdBMfIWrzrvYeqP4cfuzKG8z6xVivg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.0.1
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -728,6 +740,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1233,6 +1249,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -1476,6 +1495,16 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  size-limit@12.0.1:
+    resolution: {integrity: sha512-vuFj+6lDOoBJQu6OLhcMQv7jnbXjuoEn4WsQHlSLOV/8EFfOka/tfjtLQ/rZig5Gagi3R0GnU/0kd4EY/y2etg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2072,6 +2101,10 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@size-limit/file@12.0.1(size-limit@12.0.1)':
+    dependencies:
+      size-limit: 12.0.1
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -2259,6 +2292,8 @@ snapshots:
     dependencies:
       esbuild: 0.27.4
       load-tsconfig: 0.2.5
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.1.2: {}
 
@@ -2835,6 +2870,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -3085,6 +3124,14 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  size-limit@12.0.1:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
Closes #21

## Summary
- Install `size-limit` and `@size-limit/file` as dev dependencies
- Add `.size-limit.json` with limits for `dist/index.js` (300 KB), `dist/index.global.js` (320 KB), and `dist/teryx.css` (100 KB)
- Add `size` and `size:check` npm scripts to `package.json`

## size-limit output

```
  dist/index.js
  Size limit: 300 kB
  Size:       48.73 kB brotlied

  dist/index.global.js
  Size limit: 320 kB
  Size:       49.3 kB brotlied

  dist/teryx.css
  Size limit: 100 kB
  Size:       11.73 kB brotlied
```

## Test plan
- [x] `npx size-limit` runs without errors
- [x] All existing tests pass (383/383)