### PR TITLE
feat: Add slider and range widget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export {
   exportHTML,
   gridColumnsToExport,
   chart,
+  slider,
 } from './widgets';
 
 // Category imports

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -32,3 +32,4 @@ export { segmented } from './segmented';
 export { propertyGrid, descriptions } from './property-grid';
 export { exportCSV, exportExcel, exportJSON, exportHTML, gridColumnsToExport } from './exporter';
 export { chart } from './chart';
+export { slider } from './slider';

--- a/src/widgets/slider.ts
+++ b/src/widgets/slider.ts
@@ -1,0 +1,260 @@
+// ============================================================
+// Teryx — Slider / Range Widget
+// ============================================================
+
+import type { SliderOptions, WidgetInstance } from '../types';
+import { uid, esc, cls, resolveTarget, clamp } from '../utils';
+import { registerWidget, emit } from '../core';
+
+export interface SliderInstance extends WidgetInstance {
+  getValue(): number | [number, number];
+  setValue(value: number | [number, number]): void;
+}
+
+export function slider(target: string | HTMLElement, options: SliderOptions = {}): SliderInstance {
+  const el = resolveTarget(target);
+  const id = options.id || uid('tx-slider');
+  const min = options.min ?? 0;
+  const max = options.max ?? 100;
+  const step = options.step ?? 1;
+  const isRange = options.range ?? false;
+  const isVertical = options.vertical ?? false;
+  const showTooltip = options.showTooltip ?? true;
+  const showInput = options.showInput ?? false;
+  const marks = options.marks || {};
+
+  let value = options.value ?? min;
+  let values: [number, number] = options.values ?? [min, max];
+
+  function pct(v: number): number {
+    return ((v - min) / (max - min)) * 100;
+  }
+
+  function snap(v: number): number {
+    const snapped = Math.round((v - min) / step) * step + min;
+    return clamp(snapped, min, max);
+  }
+
+  function render(): void {
+    let html = `<div class="${cls(
+      'tx-slider',
+      isVertical && 'tx-slider-vertical',
+      isRange && 'tx-slider-range',
+      options.class,
+    )}" id="${esc(id)}">`;
+
+    // Track
+    html += '<div class="tx-slider-track">';
+
+    // Fill
+    if (isRange) {
+      const startPct = pct(values[0]);
+      const endPct = pct(values[1]);
+      if (isVertical) {
+        html += `<div class="tx-slider-fill" style="bottom:${startPct}%;height:${endPct - startPct}%"></div>`;
+      } else {
+        html += `<div class="tx-slider-fill" style="left:${startPct}%;width:${endPct - startPct}%"></div>`;
+      }
+    } else {
+      const valPct = pct(value);
+      if (isVertical) {
+        html += `<div class="tx-slider-fill" style="bottom:0;height:${valPct}%"></div>`;
+      } else {
+        html += `<div class="tx-slider-fill" style="left:0;width:${valPct}%"></div>`;
+      }
+    }
+
+    // Marks
+    const markKeys = Object.keys(marks).map(Number);
+    if (markKeys.length > 0) {
+      html += '<div class="tx-slider-marks">';
+      for (const mk of markKeys) {
+        const mkPct = pct(mk);
+        const prop = isVertical ? 'bottom' : 'left';
+        html += `<div class="tx-slider-mark" style="${prop}:${mkPct}%">`;
+        html += '<div class="tx-slider-mark-tick"></div>';
+        html += `<div class="tx-slider-mark-label">${esc(marks[mk])}</div>`;
+        html += '</div>';
+      }
+      html += '</div>';
+    }
+
+    // Thumbs
+    if (isRange) {
+      const startPct = pct(values[0]);
+      const endPct = pct(values[1]);
+      const prop = isVertical ? 'bottom' : 'left';
+      html += `<div class="tx-slider-thumb tx-slider-thumb-start" data-thumb="start" style="${prop}:${startPct}%">`;
+      if (showTooltip) html += `<div class="tx-slider-tooltip">${values[0]}</div>`;
+      html += '</div>';
+      html += `<div class="tx-slider-thumb tx-slider-thumb-end" data-thumb="end" style="${prop}:${endPct}%">`;
+      if (showTooltip) html += `<div class="tx-slider-tooltip">${values[1]}</div>`;
+      html += '</div>';
+    } else {
+      const valPct = pct(value);
+      const prop = isVertical ? 'bottom' : 'left';
+      html += `<div class="tx-slider-thumb" data-thumb="single" style="${prop}:${valPct}%">`;
+      if (showTooltip) html += `<div class="tx-slider-tooltip">${value}</div>`;
+      html += '</div>';
+    }
+
+    html += '</div>'; // track
+
+    // Optional number input
+    if (showInput) {
+      html += '<div class="tx-slider-input-wrap">';
+      if (isRange) {
+        html += `<input type="number" class="tx-input tx-input-sm tx-slider-input" data-input="start" min="${min}" max="${max}" step="${step}" value="${values[0]}">`;
+        html += '<span class="tx-slider-input-sep">-</span>';
+        html += `<input type="number" class="tx-input tx-input-sm tx-slider-input" data-input="end" min="${min}" max="${max}" step="${step}" value="${values[1]}">`;
+      } else {
+        html += `<input type="number" class="tx-input tx-input-sm tx-slider-input" data-input="single" min="${min}" max="${max}" step="${step}" value="${value}">`;
+      }
+      html += '</div>';
+    }
+
+    html += '</div>';
+    el.innerHTML = html;
+    bindEvents();
+  }
+
+  function fireChange(): void {
+    const val = isRange ? ([...values] as [number, number]) : value;
+    options.onChange?.(val);
+    emit('slider:change', { id, value: val });
+  }
+
+  function bindEvents(): void {
+    const container = el.querySelector(`#${id}`) as HTMLElement;
+    if (!container) return;
+    const track = container.querySelector('.tx-slider-track') as HTMLElement;
+    const thumbs = container.querySelectorAll('.tx-slider-thumb');
+
+    let dragging: string | null = null;
+
+    function getValueFromEvent(e: MouseEvent | TouchEvent): number {
+      const rect = track.getBoundingClientRect();
+      const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+      let ratio: number;
+      if (isVertical) {
+        ratio = 1 - (clientY - rect.top) / rect.height;
+      } else {
+        ratio = (clientX - rect.left) / rect.width;
+      }
+      ratio = clamp(ratio, 0, 1);
+      return snap(min + ratio * (max - min));
+    }
+
+    function onMove(e: MouseEvent | TouchEvent): void {
+      if (!dragging) return;
+      const newVal = getValueFromEvent(e);
+      if (isRange) {
+        if (dragging === 'start') {
+          values[0] = Math.min(newVal, values[1]);
+        } else {
+          values[1] = Math.max(newVal, values[0]);
+        }
+      } else {
+        value = newVal;
+      }
+      render();
+      fireChange();
+    }
+
+    function onUp(): void {
+      dragging = null;
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('touchend', onUp);
+    }
+
+    thumbs.forEach((thumb) => {
+      const thumbType = (thumb as HTMLElement).getAttribute('data-thumb') || 'single';
+      thumb.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        dragging = thumbType;
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+      });
+      thumb.addEventListener(
+        'touchstart',
+        (e) => {
+          dragging = thumbType;
+          document.addEventListener('touchmove', onMove, { passive: true });
+          document.addEventListener('touchend', onUp);
+        },
+        { passive: true },
+      );
+    });
+
+    // Click on track
+    track.addEventListener('mousedown', (e) => {
+      if (dragging) return;
+      const newVal = getValueFromEvent(e);
+      if (isRange) {
+        const distStart = Math.abs(newVal - values[0]);
+        const distEnd = Math.abs(newVal - values[1]);
+        if (distStart <= distEnd) {
+          values[0] = Math.min(newVal, values[1]);
+          dragging = 'start';
+        } else {
+          values[1] = Math.max(newVal, values[0]);
+          dragging = 'end';
+        }
+      } else {
+        value = newVal;
+        dragging = 'single';
+      }
+      render();
+      fireChange();
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+
+    // Number input sync
+    if (showInput) {
+      container.querySelectorAll('.tx-slider-input').forEach((inp) => {
+        inp.addEventListener('change', () => {
+          const inputEl = inp as HTMLInputElement;
+          const inputType = inputEl.getAttribute('data-input');
+          const newVal = snap(parseFloat(inputEl.value) || min);
+          if (isRange) {
+            if (inputType === 'start') values[0] = Math.min(newVal, values[1]);
+            else values[1] = Math.max(newVal, values[0]);
+          } else {
+            value = newVal;
+          }
+          render();
+          fireChange();
+        });
+      });
+    }
+  }
+
+  render();
+
+  const instance: SliderInstance = {
+    el: el.querySelector(`#${id}`) || el,
+    destroy() {
+      el.innerHTML = '';
+    },
+    getValue() {
+      return isRange ? ([...values] as [number, number]) : value;
+    },
+    setValue(val: number | [number, number]) {
+      if (isRange && Array.isArray(val)) {
+        values = [snap(val[0]), snap(val[1])];
+      } else if (!isRange && typeof val === 'number') {
+        value = snap(val);
+      }
+      render();
+    },
+  };
+
+  return instance;
+}
+
+registerWidget('slider', (el, opts) => slider(el, opts as unknown as SliderOptions));
+export default slider;

--- a/styles/teryx.css
+++ b/styles/teryx.css
@@ -1156,3 +1156,27 @@ body.tx-drawer-open { overflow: hidden; }
   .tx-hero-subtitle { font-size: 1rem; }
   .tx-descriptions-body { grid-template-columns: 1fr !important; }
 }
+
+/* === Slider / Range === */
+.tx-slider { display: flex; align-items: center; gap: var(--tx-space-3); }
+.tx-slider-track { position: relative; flex: 1; height: 6px; background: var(--tx-bg-tertiary); border-radius: var(--tx-radius-full); cursor: pointer; }
+.tx-slider-fill { position: absolute; height: 100%; background: var(--tx-primary); border-radius: var(--tx-radius-full); pointer-events: none; }
+.tx-slider-thumb { position: absolute; width: 18px; height: 18px; background: var(--tx-bg); border: 2px solid var(--tx-primary); border-radius: var(--tx-radius-full); top: 50%; transform: translate(-50%, -50%); cursor: grab; z-index: 2; transition: box-shadow var(--tx-transition); }
+.tx-slider-thumb:hover, .tx-slider-thumb:active { box-shadow: 0 0 0 4px color-mix(in srgb, var(--tx-primary) 20%, transparent); }
+.tx-slider-thumb:active { cursor: grabbing; }
+.tx-slider-tooltip { position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%); padding: 2px 6px; background: var(--tx-gray-900); color: #fff; font-size: 0.75rem; border-radius: var(--tx-radius-sm); white-space: nowrap; pointer-events: none; opacity: 0; transition: opacity var(--tx-transition); }
+.tx-slider-thumb:hover .tx-slider-tooltip, .tx-slider-thumb:active .tx-slider-tooltip { opacity: 1; }
+.tx-slider-marks { position: absolute; inset: 0; pointer-events: none; }
+.tx-slider-mark { position: absolute; top: 50%; transform: translateX(-50%); }
+.tx-slider-mark-tick { width: 2px; height: 10px; background: var(--tx-border-strong); margin: -5px auto 4px; }
+.tx-slider-mark-label { font-size: 0.6875rem; color: var(--tx-text-muted); text-align: center; white-space: nowrap; }
+.tx-slider-input-wrap { display: flex; align-items: center; gap: var(--tx-space-2); }
+.tx-slider-input { width: 64px; text-align: center; }
+.tx-slider-input-sep { color: var(--tx-text-muted); }
+/* Vertical */
+.tx-slider-vertical { flex-direction: column; height: 200px; width: auto; }
+.tx-slider-vertical .tx-slider-track { width: 6px; height: 100%; flex: 1; }
+.tx-slider-vertical .tx-slider-fill { width: 100%; height: auto; left: 0; }
+.tx-slider-vertical .tx-slider-thumb { left: 50%; top: auto; transform: translate(-50%, 50%); }
+.tx-slider-vertical .tx-slider-tooltip { bottom: auto; left: calc(100% + 8px); top: 50%; transform: translateY(-50%); }
+.tx-slider-vertical .tx-slider-mark { top: auto; left: 50%; transform: translateY(50%); }

--- a/tests/browser/slider.spec.ts
+++ b/tests/browser/slider.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, count } from './helpers';
+
+test.describe('Slider Widget', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+  });
+
+  test('renders slider track and thumb', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).Teryx.slider('#target', { value: 50 });
+    });
+    await expect(page.locator('.tx-slider-track')).toBeVisible();
+    await expect(page.locator('.tx-slider-thumb')).toBeVisible();
+  });
+
+  test('getValue returns the value', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).__sl = (window as any).Teryx.slider('#target', { value: 42 });
+    });
+    const val = await page.evaluate(() => (window as any).__sl.getValue());
+    expect(val).toBe(42);
+  });
+
+  test('setValue updates the slider', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).__sl = (window as any).Teryx.slider('#target', { value: 10 });
+    });
+    await page.evaluate(() => (window as any).__sl.setValue(75));
+    await page.waitForTimeout(200);
+    const val = await page.evaluate(() => (window as any).__sl.getValue());
+    expect(val).toBe(75);
+  });
+
+  test('range mode renders two thumbs', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).Teryx.slider('#target', { range: true, values: [20, 80] });
+    });
+    const thumbs = await count(page, '.tx-slider-thumb');
+    expect(thumbs).toBe(2);
+  });
+
+  test('marks are rendered', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).Teryx.slider('#target', { marks: { 0: 'Low', 50: 'Mid', 100: 'High' } });
+    });
+    const marks = await count(page, '.tx-slider-mark');
+    expect(marks).toBe(3);
+    await expect(page.locator('.tx-slider-mark-label').nth(0)).toHaveText('Low');
+  });
+
+  test('showInput renders number input', async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).__sl = (window as any).Teryx.slider('#target', { value: 50, showInput: true });
+    });
+    await expect(page.locator('.tx-slider-input')).toBeVisible();
+    const val = await page.locator('.tx-slider-input').inputValue();
+    expect(val).toBe('50');
+  });
+});

--- a/tests/widgets/slider.test.ts
+++ b/tests/widgets/slider.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { slider } from '../../src/widgets/slider';
+
+describe('Slider widget', () => {
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('renders a slider track and thumb', () => {
+    slider(container, {});
+    expect(container.querySelector('.tx-slider-track')).not.toBeNull();
+    expect(container.querySelector('.tx-slider-thumb')).not.toBeNull();
+  });
+
+  it('renders with default value (min)', () => {
+    const s = slider(container, { min: 0, max: 100 });
+    expect(s.getValue()).toBe(0);
+  });
+
+  it('renders with initial value', () => {
+    const s = slider(container, { value: 50, min: 0, max: 100 });
+    expect(s.getValue()).toBe(50);
+  });
+
+  it('getValue returns current value', () => {
+    const s = slider(container, { value: 42 });
+    expect(s.getValue()).toBe(42);
+  });
+
+  it('setValue updates value', () => {
+    const s = slider(container, { min: 0, max: 100 });
+    s.setValue(75);
+    expect(s.getValue()).toBe(75);
+  });
+
+  it('setValue clamps to min/max', () => {
+    const s = slider(container, { min: 10, max: 50 });
+    s.setValue(0);
+    expect(s.getValue()).toBe(10);
+    s.setValue(100);
+    expect(s.getValue()).toBe(50);
+  });
+
+  it('setValue snaps to step', () => {
+    const s = slider(container, { min: 0, max: 100, step: 10 });
+    s.setValue(23);
+    expect(s.getValue()).toBe(20);
+    s.setValue(27);
+    expect(s.getValue()).toBe(30);
+  });
+
+  it('renders fill element', () => {
+    slider(container, { value: 50 });
+    const fill = container.querySelector('.tx-slider-fill') as HTMLElement;
+    expect(fill).not.toBeNull();
+  });
+
+  it('shows tooltip on thumb', () => {
+    slider(container, { value: 50, showTooltip: true });
+    const tooltip = container.querySelector('.tx-slider-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toBe('50');
+  });
+
+  it('hides tooltip when showTooltip is false', () => {
+    slider(container, { value: 50, showTooltip: false });
+    expect(container.querySelector('.tx-slider-tooltip')).toBeNull();
+  });
+
+  it('range mode renders two thumbs', () => {
+    slider(container, { range: true, values: [20, 80] });
+    const thumbs = container.querySelectorAll('.tx-slider-thumb');
+    expect(thumbs.length).toBe(2);
+  });
+
+  it('range mode getValue returns tuple', () => {
+    const s = slider(container, { range: true, values: [20, 80] });
+    const val = s.getValue() as [number, number];
+    expect(val).toEqual([20, 80]);
+  });
+
+  it('range mode setValue updates both thumbs', () => {
+    const s = slider(container, { range: true, values: [20, 80] });
+    s.setValue([30, 70]);
+    expect(s.getValue()).toEqual([30, 70]);
+  });
+
+  it('renders marks', () => {
+    slider(container, { marks: { 0: '0%', 50: '50%', 100: '100%' } });
+    const marks = container.querySelectorAll('.tx-slider-mark');
+    expect(marks.length).toBe(3);
+  });
+
+  it('renders mark labels', () => {
+    slider(container, { marks: { 0: 'Low', 100: 'High' } });
+    const labels = container.querySelectorAll('.tx-slider-mark-label');
+    expect(labels.length).toBe(2);
+    expect(labels[0].textContent).toBe('Low');
+    expect(labels[1].textContent).toBe('High');
+  });
+
+  it('showInput renders number input', () => {
+    slider(container, { showInput: true, value: 50 });
+    const input = container.querySelector('.tx-slider-input') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe('50');
+  });
+
+  it('showInput in range mode renders two inputs', () => {
+    slider(container, { range: true, showInput: true, values: [20, 80] });
+    const inputs = container.querySelectorAll('.tx-slider-input');
+    expect(inputs.length).toBe(2);
+  });
+
+  it('vertical mode adds vertical class', () => {
+    slider(container, { vertical: true });
+    expect(container.querySelector('.tx-slider-vertical')).not.toBeNull();
+  });
+
+  it('applies custom class', () => {
+    slider(container, { class: 'my-slider' });
+    expect(container.querySelector('.tx-slider')?.classList.contains('my-slider')).toBe(true);
+  });
+
+  it('destroy clears content', () => {
+    const s = slider(container, {});
+    s.destroy();
+    expect(container.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Add numeric slider widget with single-thumb and dual-thumb (range) modes
- Draggable thumb(s) with mouse and touch support
- Optional tooltip showing current value on hover/drag
- Optional synced number input field
- Marks rendered as ticks with labels at specified positions
- Vertical orientation support

## Test plan
- [x] typecheck
- [x] unit tests (20 tests covering value, range, marks, tooltip, input, vertical)
- [x] browser tests (Playwright specs for rendering, getValue/setValue, range, marks, input)

Closes #5