### PR TITLE
Eliminate xhtmlx and deepMerge code duplication

### DIFF
--- a/src/widgets/form.ts
+++ b/src/widgets/form.ts
@@ -114,7 +114,7 @@ export function form(target: string | HTMLElement, options: FormOptions): FormIn
     setErrors(errors: Record<string, string>) {
       instance.clearErrors();
       for (const [field, message] of Object.entries(errors)) {
-        const group = formEl.querySelector(`[data-field="${field.replace(/["\\\\]/g, '\\\\$&')}"]`);
+        const group = formEl.querySelector(`[data-field="${field.replace(/["\\]/g, '\\$&')}"]`);
         if (group) {
           group.classList.add('tx-form-error');
           const errEl = group.querySelector('.tx-form-feedback');


### PR DESCRIPTION
## Summary
- Extract `processXhtmlx()` and `triggerLazyLoad()` utility functions into `src/utils.ts` to replace duplicated xhtmlx integration patterns across 11 widget files (grid, modal, tabs, tree, accordion, drawer, steps, sheet, navigation-view, bottom-tabs)
- Consolidate `deepMerge` by removing the local copy from `src/i18n.ts` and importing from `src/utils.ts`, adding a `skipUndefined` parameter to preserve the i18n version's behavior of ignoring undefined values
- Net reduction of ~26 lines of duplicated code

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` -- all 492 tests pass
- [x] Prettier reports no formatting changes needed

Closes #60