### PR TITLE
Fix memory leaks in widget lifecycle

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -266,6 +266,8 @@ export function emit(event: string, ...args: unknown[]): void {
 // ----------------------------------------------------------
 //  Auto-init on DOMContentLoaded + MutationObserver
 // ----------------------------------------------------------
+let _observer: MutationObserver | null = null;
+
 if (typeof document !== 'undefined') {
   const run = () => {
     if (config.autoInit) initWidgets();
@@ -277,7 +279,7 @@ if (typeof document !== 'undefined') {
     run();
   }
 
-  const observer = new MutationObserver((mutations) => {
+  _observer = new MutationObserver((mutations) => {
     if (!config.autoInit) return;
     for (const m of mutations) {
       for (const node of Array.from(m.addedNodes)) {
@@ -289,5 +291,13 @@ if (typeof document !== 'undefined') {
       }
     }
   });
-  observer.observe(document.documentElement, { childList: true, subtree: true });
+  _observer.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+/** Disconnect the MutationObserver to allow garbage collection. */
+export function teardown(): void {
+  if (_observer) {
+    _observer.disconnect();
+    _observer = null;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@
 //
 
 // Core
-export { configure, config, initWidgets, registerWidget, on, off, emit } from './core';
+export { configure, config, initWidgets, registerWidget, on, off, emit, teardown } from './core';
 
 // Types
 export type * from './types';

--- a/src/widgets/color-picker.ts
+++ b/src/widgets/color-picker.ts
@@ -202,22 +202,22 @@ export function colorPicker(target: string | HTMLElement, options: ColorPickerOp
     },
     { passive: true },
   );
-  document.addEventListener('mousemove', (e) => {
+  const onDocMouseMove = (e: MouseEvent) => {
     if (dragging) pickSatLight(e);
-  });
-  document.addEventListener(
-    'touchmove',
-    (e) => {
-      if (dragging) pickSatLight(e);
-    },
-    { passive: true },
-  );
-  document.addEventListener('mouseup', () => {
+  };
+  const onDocTouchMove = (e: TouchEvent) => {
+    if (dragging) pickSatLight(e);
+  };
+  const onDocMouseUp = () => {
     dragging = false;
-  });
-  document.addEventListener('touchend', () => {
+  };
+  const onDocTouchEnd = () => {
     dragging = false;
-  });
+  };
+  document.addEventListener('mousemove', onDocMouseMove);
+  document.addEventListener('touchmove', onDocTouchMove, { passive: true });
+  document.addEventListener('mouseup', onDocMouseUp);
+  document.addEventListener('touchend', onDocTouchEnd);
 
   // Preset clicks
   container.querySelectorAll('.tx-colorpicker-preset').forEach((btn) => {
@@ -240,13 +240,19 @@ export function colorPicker(target: string | HTMLElement, options: ColorPickerOp
   });
 
   // Close on outside click
-  document.addEventListener('click', (e) => {
+  const onDocClick = (e: MouseEvent) => {
     if (isOpen && !container.contains(e.target as Node)) instance.close();
-  });
+  };
+  document.addEventListener('click', onDocClick);
 
   const instance: ColorPickerInstance = {
     el: container,
     destroy() {
+      document.removeEventListener('mousemove', onDocMouseMove);
+      document.removeEventListener('touchmove', onDocTouchMove);
+      document.removeEventListener('mouseup', onDocMouseUp);
+      document.removeEventListener('touchend', onDocTouchEnd);
+      document.removeEventListener('click', onDocClick);
       el.innerHTML = '';
     },
     getValue() {

--- a/src/widgets/drawer.ts
+++ b/src/widgets/drawer.ts
@@ -92,6 +92,7 @@ export function drawer(options: DrawerOptions): DrawerInstance {
     },
     destroy() {
       if (instance.isOpen()) instance.close();
+      document.removeEventListener('keydown', escapeHandler);
       setTimeout(() => overlay.remove(), 350);
     },
   };
@@ -107,9 +108,10 @@ export function drawer(options: DrawerOptions): DrawerInstance {
   }
 
   // Escape
-  document.addEventListener('keydown', (e) => {
+  const escapeHandler = (e: KeyboardEvent) => {
     if (e.key === 'Escape' && instance.isOpen()) instance.close();
-  });
+  };
+  document.addEventListener('keydown', escapeHandler);
 
   return instance;
 }

--- a/src/widgets/dropdown.ts
+++ b/src/widgets/dropdown.ts
@@ -55,16 +55,18 @@ export function dropdown(options: DropdownOptions): DropdownInstance {
   });
 
   // Click outside
-  document.addEventListener('click', (e) => {
+  const outsideClickHandler = (e: MouseEvent) => {
     if (isOpen && !menuEl.contains(e.target as Node) && !triggerEl.contains(e.target as Node)) {
       close();
     }
-  });
+  };
+  document.addEventListener('click', outsideClickHandler);
 
   // Escape key
-  document.addEventListener('keydown', (e) => {
+  const escapeKeyHandler = (e: KeyboardEvent) => {
     if (e.key === 'Escape' && isOpen) close();
-  });
+  };
+  document.addEventListener('keydown', escapeKeyHandler);
 
   // Menu item clicks
   menuEl.addEventListener('click', (e) => {
@@ -82,6 +84,8 @@ export function dropdown(options: DropdownOptions): DropdownInstance {
   const instance: DropdownInstance = {
     el: menuEl,
     destroy() {
+      document.removeEventListener('click', outsideClickHandler);
+      document.removeEventListener('keydown', escapeKeyHandler);
       menuEl.remove();
     },
     open,
@@ -133,13 +137,15 @@ export function contextMenu(options: MenuOptions): MenuInstance {
   }
 
   // Click outside
-  document.addEventListener('click', (e) => {
+  const ctxOutsideHandler = (e: MouseEvent) => {
     if (isOpen && !menuEl.contains(e.target as Node)) close();
-  });
+  };
+  document.addEventListener('click', ctxOutsideHandler);
 
-  document.addEventListener('keydown', (e) => {
+  const ctxEscapeHandler = (e: KeyboardEvent) => {
     if (e.key === 'Escape' && isOpen) close();
-  });
+  };
+  document.addEventListener('keydown', ctxEscapeHandler);
 
   // Item clicks
   menuEl.addEventListener('click', (e) => {
@@ -156,6 +162,8 @@ export function contextMenu(options: MenuOptions): MenuInstance {
   return {
     el: menuEl,
     destroy() {
+      document.removeEventListener('click', ctxOutsideHandler);
+      document.removeEventListener('keydown', ctxEscapeHandler);
       menuEl.remove();
     },
     open,

--- a/src/widgets/modal.ts
+++ b/src/widgets/modal.ts
@@ -146,6 +146,10 @@ export function modal(options: ModalOptions): ModalInstance {
     },
     destroy() {
       if (instance.isOpen()) instance.close();
+      // Remove document-level keydown listener to prevent memory leak
+      if ((overlay as any)._keyHandler) {
+        document.removeEventListener('keydown', (overlay as any)._keyHandler);
+      }
       setTimeout(() => overlay.remove(), 250);
     },
   };


### PR DESCRIPTION
## Summary

- **modal.ts**: Remove the document-level `keydown` listener (stored on `overlay._keyHandler`) in `destroy()` to prevent leaked references.
- **drawer.ts**: Store the escape key handler as a named function; remove it from `document` in `destroy()`.
- **dropdown.ts**: Store click-outside and escape key handlers as named variables; remove both in `destroy()` for `dropdown()` and `contextMenu()`.
- **color-picker.ts**: Store all document-level handlers (`mousemove`, `mouseup`, `touchmove`, `touchend`, `click`) as named functions; remove all in `destroy()`.
- **core.ts**: Store the `MutationObserver` in a module-level variable; export a `teardown()` function that disconnects it, enabling proper cleanup in SPAs and tests.
- **index.ts**: Re-export `teardown` from the public API.

## Test plan

- [x] All 512 existing tests pass
- [x] TypeScript compiles without errors
- [x] Prettier formatting verified
- [ ] Manual verification: create and destroy widgets in a loop, confirm no growing listener count in DevTools
- [ ] Manual verification: call `teardown()` and confirm MutationObserver is disconnected

Closes #57