### PR TITLE
Fix correctness bugs in toast, grid, drawer, tabs, chart, and utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,14 +87,17 @@ export function throttle<T extends (...args: unknown[]) => void>(fn: T, ms: numb
       fn(...args);
     } else {
       lastArgs = args;
-      trailingTimer = setTimeout(() => {
-        last = Date.now();
-        trailingTimer = null;
-        if (lastArgs) {
-          fn(...lastArgs);
-          lastArgs = null;
-        }
-      }, ms - (now - last));
+      trailingTimer = setTimeout(
+        () => {
+          last = Date.now();
+          trailingTimer = null;
+          if (lastArgs) {
+            fn(...lastArgs);
+            lastArgs = null;
+          }
+        },
+        ms - (now - last),
+      );
     }
   }) as unknown as T;
 }


### PR DESCRIPTION
## Summary
- **Toast**: Track elapsed time properly on hover pause/resume instead of using `duration / 2`; resume with `Math.max(500, duration - elapsed)`
- **Grid**: `setPage()` now reads the current `xh-get` attribute to preserve existing sort/search params instead of rebuilding from `options.source`
- **Drawer**: Track open drawers with a module-level `Set` (matching modal.ts pattern); only remove `tx-drawer-open` from body when all drawers are closed
- **Tabs**: Set `aria-selected="false"` on the old tab when deactivating, matching the new tab getting `aria-selected="true"`
- **Chart**: Guard `Math.min`/`Math.max` calls against empty arrays in all chart renderers (bar, horizontalBar, line, area, scatter)
- **Utils**: Add trailing-edge support to `throttle()` so the last call during a throttle window fires after the window expires

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx prettier --write` on changed files
- [x] `npx vitest run` -- all 512 tests pass

Closes #58