### PR TITLE
Performance optimizations in esc(), attribute parsing, and calendar

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -111,7 +111,8 @@ const boolAttrs = new Set([
 /** Parse all attributes of an element into a plain object. */
 function parseElementAttrs(el: Element): Record<string, unknown> {
   const obj: Record<string, unknown> = {};
-  for (const a of Array.from(el.attributes)) {
+  for (let i = 0; i < el.attributes.length; i++) {
+    const a = el.attributes[i];
     const key = a.name.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
 
     // Boolean attribute (present without value, or value="true"/"false")
@@ -186,7 +187,8 @@ function parseChildren(el: HTMLElement): Record<string, unknown[]> {
 /** Parse data-tx-* attributes into an options object. */
 function parseDataAttrs(el: HTMLElement): Record<string, unknown> {
   const opts: Record<string, unknown> = {};
-  for (const a of Array.from(el.attributes)) {
+  for (let i = 0; i < el.attributes.length; i++) {
+    const a = el.attributes[i];
     if (a.name.startsWith('data-tx-') && a.name !== 'data-tx-widget' && a.name !== 'data-tx-initialized') {
       const key = a.name.slice(8).replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,16 +9,17 @@ export function uid(prefix = 'tx'): string {
   return `${prefix}-${++_idCounter}`;
 }
 
+const escMap: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
 /** HTML-escape a string. */
 export function esc(str: string): string {
-  const map: Record<string, string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-  };
-  return str.replace(/[&<>"']/g, (ch) => map[ch]!);
+  return str.replace(/[&<>"']/g, (ch) => escMap[ch]!);
 }
 
 /** Resolve a CSS selector or HTMLElement to an element, throwing if not found. */

--- a/src/widgets/calendar.ts
+++ b/src/widgets/calendar.ts
@@ -339,13 +339,24 @@ export function calendar(target: string | HTMLElement, options: CalendarOptions)
     }
     h += '</div></div>';
 
+    // Pre-compute events per day (avoids calling getEventsForDate twice per day)
+    const dayEventsMap = new Map<string, { allDay: CalendarEvent[]; timed: CalendarEvent[] }>();
+    for (const d of days) {
+      const dateStr = fmtDate(d);
+      const evts = getEventsForDate(d);
+      dayEventsMap.set(dateStr, {
+        allDay: evts.filter((e) => isAllDay(e)),
+        timed: evts.filter((e) => !isAllDay(e)),
+      });
+    }
+
     // All-day events row
     h += '<div class="tx-calendar-allday-row">';
     h += '<div class="tx-calendar-allday-label">all-day</div>';
     h += '<div class="tx-calendar-allday-cells">';
     for (const d of days) {
       const dateStr = fmtDate(d);
-      const allDayEvts = getEventsForDate(d).filter((e) => isAllDay(e));
+      const allDayEvts = dayEventsMap.get(dateStr)!.allDay;
       h += `<div class="tx-calendar-allday-cell" data-date="${dateStr}">`;
       for (const ev of allDayEvts) {
         h += `<span class="tx-calendar-event" data-event-id="${esc(ev.id)}" style="background:${eventColor(ev)}" title="${esc(ev.title)}">${esc(ev.title)}</span>`;
@@ -377,7 +388,7 @@ export function calendar(target: string | HTMLElement, options: CalendarOptions)
       }
 
       // Timed events
-      const timedEvts = getEventsForDate(d).filter((e) => !isAllDay(e));
+      const timedEvts = dayEventsMap.get(dateStr)!.timed;
       for (const ev of timedEvts) {
         const startDt = parseEventDateTime(ev.start);
         const endDt = ev.end ? parseEventDateTime(ev.end) : new Date(startDt.getTime() + 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- **src/utils.ts**: Move the `map` object in `esc()` to module scope (`escMap`) so it is not re-allocated on every call
- **src/core.ts**: Replace `Array.from(el.attributes)` with index-based `for` loops in `parseElementAttrs()` and `parseDataAttrs()` to avoid allocating intermediate arrays
- **src/widgets/calendar.ts**: Refactor `renderTimedView()` to call `getEventsForDate()` once per day (was called twice -- once for all-day events, once for timed events), storing results in a `dayEventsMap`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx prettier --write` on changed files (all unchanged)
- [x] `npx vitest run` -- all 512 tests pass

Closes #59