### PR TITLE
Add grid row grouping support

### DIFF
--- a/src/widgets/grid.ts
+++ b/src/widgets/grid.ts
@@ -42,7 +42,11 @@ export function grid(target: string | HTMLElement, options: GridOptions): GridIn
   html += `<div id="${esc(id)}-data"`;
   html += ` xh-get="${esc(options.source)}"`;
   html += ` xh-trigger="${triggerParts.join(', ')}"`;
-  html += ` xh-indicator="#${esc(id)}-loading">`;
+  html += ` xh-indicator="#${esc(id)}-loading"`;
+  if (options.groupBy) {
+    html += ` data-group-by="${esc(options.groupBy)}"`;
+  }
+  html += `>`;
 
   // Inline xhtmlx template
   html += `<template>`;
@@ -65,7 +69,7 @@ export function grid(target: string | HTMLElement, options: GridOptions): GridIn
 
   el.innerHTML = html;
 
-  // --- Post-render: attach sort click handlers, cell editing, locked scroll sync ---
+  // --- Post-render: attach sort click handlers, cell editing, locked scroll sync, grouping ---
   requestAnimationFrame(() => {
     attachSortHandlers(el, id, options);
     if (options.editable) {
@@ -73,6 +77,9 @@ export function grid(target: string | HTMLElement, options: GridOptions): GridIn
     }
     if (hasLockedCols) {
       attachLockedScrollSync(el);
+    }
+    if (options.groupBy) {
+      attachGroupByHandlers(el, id, options);
     }
   });
 
@@ -529,6 +536,135 @@ function attachCellEditHandlers(root: HTMLElement, _id: string, options: GridOpt
         td.innerHTML = originalHTML;
       }
     });
+  });
+}
+
+// ----------------------------------------------------------
+// Row grouping (post-render)
+// ----------------------------------------------------------
+function attachGroupByHandlers(root: HTMLElement, id: string, options: GridOptions): void {
+  if (!options.groupBy) return;
+  const groupByField: string = options.groupBy;
+
+  const dataEl = document.getElementById(`${id}-data`);
+  if (!dataEl) return;
+
+  // Determine the column index for the groupBy field
+  const visibleCols = options.columns.filter((c) => !c.hidden);
+  let fieldColIndex = visibleCols.findIndex((c) => c.field === groupByField);
+  if (fieldColIndex === -1) return;
+
+  // Account for extra columns (row numbers, selectable)
+  let colOffset = 0;
+  if (options.rowNumbers) colOffset++;
+  if (options.selectable) colOffset++;
+  fieldColIndex += colOffset;
+
+  const totalCols = visibleCols.length + colOffset;
+
+  function applyGrouping(): void {
+    const tbody = dataEl!.querySelector('tbody');
+    if (!tbody) return;
+
+    const rows = Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr.tx-grid-row'));
+    if (rows.length === 0) return;
+
+    // Already grouped? Remove old group headers first
+    tbody.querySelectorAll('.tx-grid-group-header').forEach((h) => h.remove());
+    rows.forEach((r) => {
+      r.style.display = '';
+      r.removeAttribute('data-group-value');
+    });
+
+    // Build groups in order of first appearance
+    const groupOrder: string[] = [];
+    const groupRows: Map<string, HTMLTableRowElement[]> = new Map();
+
+    for (const row of rows) {
+      const cells = row.querySelectorAll('td');
+      const cell = cells[fieldColIndex];
+      const value = cell ? (cell.textContent || '').trim() : '';
+      row.setAttribute('data-group-value', value);
+
+      if (!groupRows.has(value)) {
+        groupOrder.push(value);
+        groupRows.set(value, []);
+      }
+      groupRows.get(value)!.push(row);
+    }
+
+    // Insert group header rows and rearrange
+    for (const groupValue of groupOrder) {
+      const groupRowsList = groupRows.get(groupValue)!;
+
+      const headerRow = document.createElement('tr');
+      headerRow.className = 'tx-grid-group-header';
+      headerRow.setAttribute('data-group-value', groupValue);
+
+      const headerCell = document.createElement('td');
+      headerCell.colSpan = totalCols;
+      headerCell.innerHTML =
+        `<span class="tx-grid-group-toggle">${icon('chevronDown')}</span>` +
+        `${esc(groupByField)}: ${esc(groupValue)}` +
+        `<span class="tx-grid-group-count">(${groupRowsList.length})</span>`;
+      headerRow.appendChild(headerCell);
+
+      // Insert header before first row of the group
+      tbody.insertBefore(headerRow, groupRowsList[0]);
+
+      // Ensure group rows follow the header in order
+      let insertAfter: Node = headerRow;
+      for (const row of groupRowsList) {
+        if (insertAfter.nextSibling) {
+          tbody.insertBefore(row, insertAfter.nextSibling);
+        } else {
+          tbody.appendChild(row);
+        }
+        insertAfter = row;
+      }
+    }
+  }
+
+  // Observe mutations on the data element for when xhtmlx renders or re-renders
+  const observer = new MutationObserver(() => {
+    // Delay to allow xhtmlx to finish rendering
+    requestAnimationFrame(() => applyGrouping());
+  });
+
+  observer.observe(dataEl, { childList: true, subtree: true });
+
+  // Also try to apply immediately in case content is already rendered
+  applyGrouping();
+
+  // Event delegation for group header collapse/expand
+  root.addEventListener('click', (e) => {
+    const headerRow = (e.target as HTMLElement).closest('.tx-grid-group-header') as HTMLTableRowElement | null;
+    if (!headerRow) return;
+
+    const groupValue = headerRow.getAttribute('data-group-value') || '';
+    const isCollapsed = headerRow.classList.contains('tx-grid-group-collapsed');
+
+    if (isCollapsed) {
+      // Expand
+      headerRow.classList.remove('tx-grid-group-collapsed');
+      let sibling = headerRow.nextElementSibling as HTMLTableRowElement | null;
+      while (sibling && !sibling.classList.contains('tx-grid-group-header')) {
+        if (sibling.getAttribute('data-group-value') === groupValue) {
+          sibling.style.display = '';
+        }
+        sibling = sibling.nextElementSibling as HTMLTableRowElement | null;
+      }
+    } else {
+      // Collapse
+      headerRow.classList.add('tx-grid-group-collapsed');
+      let sibling = headerRow.nextElementSibling as HTMLTableRowElement | null;
+      while (sibling && !sibling.classList.contains('tx-grid-group-header')) {
+        if (sibling.getAttribute('data-group-value') === groupValue) {
+          sibling.style.display = 'none';
+        }
+        sibling = sibling.nextElementSibling as HTMLTableRowElement | null;
+      }
+    }
   });
 }
 

--- a/styles/teryx.css
+++ b/styles/teryx.css
@@ -810,6 +810,28 @@
   display: flex;
   gap: var(--tx-space-1);
 }
+.tx-grid-group-header {
+  cursor: pointer;
+  background: var(--tx-bg-tertiary);
+  font-weight: 600;
+}
+.tx-grid-group-header:hover {
+  background: var(--tx-bg-secondary);
+}
+.tx-grid-group-toggle {
+  display: inline-flex;
+  transition: transform 150ms;
+  margin-right: 0.5rem;
+}
+.tx-grid-group-collapsed .tx-grid-group-toggle {
+  transform: rotate(-90deg);
+}
+.tx-grid-group-count {
+  color: var(--tx-text-muted);
+  font-weight: 400;
+  margin-left: 0.5rem;
+  font-size: 0.8125rem;
+}
 
 /* === Card === */
 .tx-card {
@@ -4935,46 +4957,260 @@ body.tx-drawer-open {
 }
 
 /* === Tooltip === */
-.tx-tooltip { z-index: 1070; max-width: 280px; padding: var(--tx-space-2) var(--tx-space-3); background: var(--tx-gray-900); color: #fff; font-size: 0.8125rem; border-radius: var(--tx-radius); box-shadow: var(--tx-shadow-md); transition: opacity var(--tx-transition); pointer-events: none; }
-.tx-tooltip-content { line-height: 1.4; }
-.tx-tooltip-arrow { position: absolute; width: 8px; height: 8px; background: var(--tx-gray-900); transform: rotate(45deg); }
-.tx-tooltip-arrow-top { bottom: -4px; left: 50%; margin-left: -4px; }
-.tx-tooltip-arrow-bottom { top: -4px; left: 50%; margin-left: -4px; }
-.tx-tooltip-arrow-left { right: -4px; top: 50%; margin-top: -4px; }
-.tx-tooltip-arrow-right { left: -4px; top: 50%; margin-top: -4px; }
+.tx-tooltip {
+  z-index: 1070;
+  max-width: 280px;
+  padding: var(--tx-space-2) var(--tx-space-3);
+  background: var(--tx-gray-900);
+  color: #fff;
+  font-size: 0.8125rem;
+  border-radius: var(--tx-radius);
+  box-shadow: var(--tx-shadow-md);
+  transition: opacity var(--tx-transition);
+  pointer-events: none;
+}
+.tx-tooltip-content {
+  line-height: 1.4;
+}
+.tx-tooltip-arrow {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: var(--tx-gray-900);
+  transform: rotate(45deg);
+}
+.tx-tooltip-arrow-top {
+  bottom: -4px;
+  left: 50%;
+  margin-left: -4px;
+}
+.tx-tooltip-arrow-bottom {
+  top: -4px;
+  left: 50%;
+  margin-left: -4px;
+}
+.tx-tooltip-arrow-left {
+  right: -4px;
+  top: 50%;
+  margin-top: -4px;
+}
+.tx-tooltip-arrow-right {
+  left: -4px;
+  top: 50%;
+  margin-top: -4px;
+}
 /* === Popover === */
-.tx-popover { z-index: 1070; min-width: 200px; max-width: 360px; background: var(--tx-bg); color: var(--tx-text); border: 1px solid var(--tx-border); border-radius: var(--tx-radius-lg); box-shadow: var(--tx-shadow-lg); transition: opacity var(--tx-transition); }
-.tx-popover-header { display: flex; align-items: center; justify-content: space-between; padding: var(--tx-space-3) var(--tx-space-4); border-bottom: 1px solid var(--tx-border); }
-.tx-popover-title { font-weight: 600; font-size: 0.875rem; }
-.tx-popover-close { display: flex; align-items: center; justify-content: center; background: none; border: none; cursor: pointer; color: var(--tx-text-muted); padding: var(--tx-space-1); border-radius: var(--tx-radius-sm); transition: color var(--tx-transition), background var(--tx-transition); }
-.tx-popover-close:hover { color: var(--tx-text); background: var(--tx-bg-tertiary); }
-.tx-popover-body { padding: var(--tx-space-3) var(--tx-space-4); font-size: 0.875rem; line-height: 1.5; }
-.tx-popover-arrow { position: absolute; width: 10px; height: 10px; background: var(--tx-bg); border: 1px solid var(--tx-border); transform: rotate(45deg); }
-.tx-popover-arrow-top { bottom: -6px; left: 50%; margin-left: -5px; border-top: none; border-left: none; }
-.tx-popover-arrow-bottom { top: -6px; left: 50%; margin-left: -5px; border-bottom: none; border-right: none; }
-.tx-popover-arrow-left { right: -6px; top: 50%; margin-top: -5px; border-bottom: none; border-left: none; }
-.tx-popover-arrow-right { left: -6px; top: 50%; margin-top: -5px; border-top: none; border-right: none; }
+.tx-popover {
+  z-index: 1070;
+  min-width: 200px;
+  max-width: 360px;
+  background: var(--tx-bg);
+  color: var(--tx-text);
+  border: 1px solid var(--tx-border);
+  border-radius: var(--tx-radius-lg);
+  box-shadow: var(--tx-shadow-lg);
+  transition: opacity var(--tx-transition);
+}
+.tx-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--tx-space-3) var(--tx-space-4);
+  border-bottom: 1px solid var(--tx-border);
+}
+.tx-popover-title {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+.tx-popover-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--tx-text-muted);
+  padding: var(--tx-space-1);
+  border-radius: var(--tx-radius-sm);
+  transition:
+    color var(--tx-transition),
+    background var(--tx-transition);
+}
+.tx-popover-close:hover {
+  color: var(--tx-text);
+  background: var(--tx-bg-tertiary);
+}
+.tx-popover-body {
+  padding: var(--tx-space-3) var(--tx-space-4);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+.tx-popover-arrow {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: var(--tx-bg);
+  border: 1px solid var(--tx-border);
+  transform: rotate(45deg);
+}
+.tx-popover-arrow-top {
+  bottom: -6px;
+  left: 50%;
+  margin-left: -5px;
+  border-top: none;
+  border-left: none;
+}
+.tx-popover-arrow-bottom {
+  top: -6px;
+  left: 50%;
+  margin-left: -5px;
+  border-bottom: none;
+  border-right: none;
+}
+.tx-popover-arrow-left {
+  right: -6px;
+  top: 50%;
+  margin-top: -5px;
+  border-bottom: none;
+  border-left: none;
+}
+.tx-popover-arrow-right {
+  left: -6px;
+  top: 50%;
+  margin-top: -5px;
+  border-top: none;
+  border-right: none;
+}
 /* === Date Picker === */
-.tx-datepicker { position: relative; display: inline-block; }
-.tx-datepicker-inline { display: block; }
-.tx-datepicker-trigger { position: relative; display: inline-flex; align-items: center; }
-.tx-datepicker-input { padding-right: 2.5rem !important; cursor: pointer; }
-.tx-datepicker-icon { position: absolute; right: var(--tx-space-3); top: 50%; transform: translateY(-50%); pointer-events: none; color: var(--tx-text-muted); }
-.tx-datepicker-dropdown { position: absolute; top: 100%; left: 0; z-index: 1060; margin-top: var(--tx-space-1); background: var(--tx-bg); border: 1px solid var(--tx-border); border-radius: var(--tx-radius-lg); box-shadow: var(--tx-shadow-lg); padding: var(--tx-space-3); min-width: 280px; }
-.tx-datepicker-inline .tx-datepicker-dropdown { position: static; margin-top: 0; box-shadow: none; border: 1px solid var(--tx-border); }
-.tx-datepicker-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--tx-space-2); }
-.tx-datepicker-title { font-weight: 600; font-size: 0.875rem; }
-.tx-datepicker-nav { display: flex; align-items: center; justify-content: center; width: 28px; height: 28px; background: none; border: none; border-radius: var(--tx-radius); cursor: pointer; color: var(--tx-text-secondary); transition: background var(--tx-transition), color var(--tx-transition); }
-.tx-datepicker-nav:hover { background: var(--tx-bg-secondary); color: var(--tx-text); }
-.tx-datepicker-weekdays { display: grid; grid-template-columns: repeat(7, 1fr); text-align: center; margin-bottom: var(--tx-space-1); }
-.tx-datepicker-weekday { font-size: 0.75rem; font-weight: 600; color: var(--tx-text-muted); padding: var(--tx-space-1) 0; }
-.tx-datepicker-days { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; }
-.tx-datepicker-day { display: flex; align-items: center; justify-content: center; width: 36px; height: 36px; font-size: 0.8125rem; border-radius: var(--tx-radius); cursor: pointer; transition: background var(--tx-transition), color var(--tx-transition); }
-.tx-datepicker-day:hover:not(.tx-datepicker-day-disabled):not(.tx-datepicker-day-other) { background: var(--tx-bg-secondary); }
-.tx-datepicker-day-other { color: var(--tx-text-muted); opacity: 0.4; cursor: default; }
-.tx-datepicker-day-today { font-weight: 700; color: var(--tx-primary); }
-.tx-datepicker-day-selected { background: var(--tx-primary) !important; color: #fff !important; font-weight: 600; }
-.tx-datepicker-day-disabled { opacity: 0.3; cursor: not-allowed; }
-.tx-datepicker-day-in-range { background: color-mix(in srgb, var(--tx-primary) 15%, transparent); }
-.tx-datepicker-day-range-start { border-radius: var(--tx-radius) 0 0 var(--tx-radius); }
-.tx-datepicker-day-range-end { border-radius: 0 var(--tx-radius) var(--tx-radius) 0; }
+.tx-datepicker {
+  position: relative;
+  display: inline-block;
+}
+.tx-datepicker-inline {
+  display: block;
+}
+.tx-datepicker-trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.tx-datepicker-input {
+  padding-right: 2.5rem !important;
+  cursor: pointer;
+}
+.tx-datepicker-icon {
+  position: absolute;
+  right: var(--tx-space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--tx-text-muted);
+}
+.tx-datepicker-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1060;
+  margin-top: var(--tx-space-1);
+  background: var(--tx-bg);
+  border: 1px solid var(--tx-border);
+  border-radius: var(--tx-radius-lg);
+  box-shadow: var(--tx-shadow-lg);
+  padding: var(--tx-space-3);
+  min-width: 280px;
+}
+.tx-datepicker-inline .tx-datepicker-dropdown {
+  position: static;
+  margin-top: 0;
+  box-shadow: none;
+  border: 1px solid var(--tx-border);
+}
+.tx-datepicker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--tx-space-2);
+}
+.tx-datepicker-title {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+.tx-datepicker-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: none;
+  border-radius: var(--tx-radius);
+  cursor: pointer;
+  color: var(--tx-text-secondary);
+  transition:
+    background var(--tx-transition),
+    color var(--tx-transition);
+}
+.tx-datepicker-nav:hover {
+  background: var(--tx-bg-secondary);
+  color: var(--tx-text);
+}
+.tx-datepicker-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  margin-bottom: var(--tx-space-1);
+}
+.tx-datepicker-weekday {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--tx-text-muted);
+  padding: var(--tx-space-1) 0;
+}
+.tx-datepicker-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+}
+.tx-datepicker-day {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  font-size: 0.8125rem;
+  border-radius: var(--tx-radius);
+  cursor: pointer;
+  transition:
+    background var(--tx-transition),
+    color var(--tx-transition);
+}
+.tx-datepicker-day:hover:not(.tx-datepicker-day-disabled):not(.tx-datepicker-day-other) {
+  background: var(--tx-bg-secondary);
+}
+.tx-datepicker-day-other {
+  color: var(--tx-text-muted);
+  opacity: 0.4;
+  cursor: default;
+}
+.tx-datepicker-day-today {
+  font-weight: 700;
+  color: var(--tx-primary);
+}
+.tx-datepicker-day-selected {
+  background: var(--tx-primary) !important;
+  color: #fff !important;
+  font-weight: 600;
+}
+.tx-datepicker-day-disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+.tx-datepicker-day-in-range {
+  background: color-mix(in srgb, var(--tx-primary) 15%, transparent);
+}
+.tx-datepicker-day-range-start {
+  border-radius: var(--tx-radius) 0 0 var(--tx-radius);
+}
+.tx-datepicker-day-range-end {
+  border-radius: 0 var(--tx-radius) var(--tx-radius) 0;
+}


### PR DESCRIPTION
## Summary
- Add `groupBy` option to GridOptions for client-side row grouping
- When set, rows are grouped by the specified field value after xhtmlx renders the table
- Each group gets a collapsible header row showing field value, row count, and a toggle chevron
- Clicking the group header collapses/expands the group's rows
- Uses event delegation and MutationObserver for post-render grouping
- Adds CSS styles for group headers with hover states and animated toggle

## Test plan
- [x] TypeScript compiles without errors
- [x] All 512 existing tests pass
- [x] Prettier formatting verified

Closes #14