### PR TITLE
Add drag-and-drop infrastructure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,8 @@ export {
   richEditor,
   tooltip,
   popover,
+  draggable,
+  droppable,
 } from './widgets';
 
 // Category imports

--- a/src/widgets/drag-drop.ts
+++ b/src/widgets/drag-drop.ts
@@ -1,0 +1,307 @@
+// ============================================================
+// Teryx — Drag & Drop Infrastructure
+// ============================================================
+
+import { uid, cls } from '../utils';
+import { registerWidget, emit } from '../core';
+
+// ----------------------------------------------------------
+//  Types
+// ----------------------------------------------------------
+
+export interface DraggableOptions {
+  /** Arbitrary payload attached to the drag operation. */
+  data?: unknown;
+  /** CSS selector for the drag handle within the element. If omitted the whole element is the handle. */
+  handle?: string;
+  /** Create a semi-transparent ghost clone while dragging. */
+  ghost?: boolean;
+  /** Callback fired when dragging starts. */
+  onDragStart?: (el: HTMLElement, data: unknown) => void;
+  /** Callback fired when dragging ends. */
+  onDragEnd?: (el: HTMLElement, data: unknown) => void;
+  /** Extra CSS class added to the element while it is being dragged. */
+  class?: string;
+}
+
+export interface DroppableOptions {
+  /** Filter function — return true to accept the dragged payload. */
+  accept?: (data: unknown) => boolean;
+  /** Callback fired while a draggable hovers over this drop target. */
+  onDragOver?: (el: HTMLElement, data: unknown) => void;
+  /** Callback fired when a draggable leaves this drop target. */
+  onDragLeave?: (el: HTMLElement, data: unknown) => void;
+  /** Callback fired when an accepted payload is dropped. */
+  onDrop?: (el: HTMLElement, data: unknown) => void;
+  /** CSS class added to the droppable while a valid draggable hovers over it. */
+  hoverClass?: string;
+}
+
+export interface DraggableInstance {
+  /** The draggable element. */
+  el: HTMLElement;
+  /** Tear down all listeners. */
+  destroy(): void;
+}
+
+export interface DroppableInstance {
+  /** The droppable element. */
+  el: HTMLElement;
+  /** Tear down the droppable registration. */
+  destroy(): void;
+}
+
+// ----------------------------------------------------------
+//  Internal state
+// ----------------------------------------------------------
+
+interface DragState {
+  el: HTMLElement;
+  data: unknown;
+  ghost: HTMLElement | null;
+  offsetX: number;
+  offsetY: number;
+  options: DraggableOptions;
+  started: boolean;
+}
+
+let _active: DragState | null = null;
+
+const _droppables = new Set<{
+  el: HTMLElement;
+  options: DroppableOptions;
+}>();
+
+// ----------------------------------------------------------
+//  Ghost helpers
+// ----------------------------------------------------------
+
+function createGhost(source: HTMLElement): HTMLElement {
+  const ghost = source.cloneNode(true) as HTMLElement;
+  ghost.id = uid('tx-drag-ghost');
+  ghost.classList.add('tx-drag-ghost');
+  ghost.style.position = 'fixed';
+  ghost.style.pointerEvents = 'none';
+  ghost.style.opacity = '0.7';
+  ghost.style.zIndex = '99999';
+  ghost.style.margin = '0';
+  ghost.style.width = `${source.offsetWidth}px`;
+  ghost.style.height = `${source.offsetHeight}px`;
+  document.body.appendChild(ghost);
+  return ghost;
+}
+
+function positionGhost(ghost: HTMLElement, clientX: number, clientY: number, offsetX: number, offsetY: number): void {
+  ghost.style.left = `${clientX - offsetX}px`;
+  ghost.style.top = `${clientY - offsetY}px`;
+}
+
+function removeGhost(ghost: HTMLElement | null): void {
+  if (ghost && ghost.parentNode) {
+    ghost.parentNode.removeChild(ghost);
+  }
+}
+
+// ----------------------------------------------------------
+//  Hit-testing droppables
+// ----------------------------------------------------------
+
+function droppableAt(x: number, y: number): { el: HTMLElement; options: DroppableOptions } | null {
+  for (const entry of _droppables) {
+    const rect = entry.el.getBoundingClientRect();
+    if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+// ----------------------------------------------------------
+//  Unified pointer helpers (mouse + touch)
+// ----------------------------------------------------------
+
+function getPointer(e: MouseEvent | TouchEvent): { clientX: number; clientY: number } {
+  if ('touches' in e) {
+    const t = e.touches[0] || (e as TouchEvent).changedTouches[0];
+    return { clientX: t.clientX, clientY: t.clientY };
+  }
+  return { clientX: (e as MouseEvent).clientX, clientY: (e as MouseEvent).clientY };
+}
+
+// ----------------------------------------------------------
+//  Core move / end handlers (attached to document)
+// ----------------------------------------------------------
+
+let _currentHover: { el: HTMLElement; options: DroppableOptions } | null = null;
+
+function handleMove(e: MouseEvent | TouchEvent): void {
+  if (!_active) return;
+  const { clientX, clientY } = getPointer(e);
+
+  // First real movement — fire drag:start
+  if (!_active.started) {
+    _active.started = true;
+    const dragClass = _active.options.class || 'tx-dragging';
+    _active.el.classList.add(dragClass);
+    _active.options.onDragStart?.(_active.el, _active.data);
+    emit('drag:start', { el: _active.el, data: _active.data });
+  }
+
+  // Move ghost
+  if (_active.ghost) {
+    positionGhost(_active.ghost, clientX, clientY, _active.offsetX, _active.offsetY);
+  }
+
+  // Hit-test droppables
+  const hit = droppableAt(clientX, clientY);
+
+  if (hit && hit !== _currentHover) {
+    // Leaving old
+    if (_currentHover) {
+      if (_currentHover.options.hoverClass) _currentHover.el.classList.remove(_currentHover.options.hoverClass);
+      _currentHover.options.onDragLeave?.(_currentHover.el, _active.data);
+      emit('drag:leave', { el: _currentHover.el, data: _active.data });
+    }
+    // Check accept
+    const accepted = hit.options.accept ? hit.options.accept(_active.data) : true;
+    if (accepted) {
+      _currentHover = hit;
+      if (hit.options.hoverClass) hit.el.classList.add(hit.options.hoverClass);
+      hit.options.onDragOver?.(hit.el, _active.data);
+      emit('drag:over', { el: hit.el, data: _active.data });
+    } else {
+      _currentHover = null;
+    }
+  } else if (!hit && _currentHover) {
+    if (_currentHover.options.hoverClass) _currentHover.el.classList.remove(_currentHover.options.hoverClass);
+    _currentHover.options.onDragLeave?.(_currentHover.el, _active.data);
+    emit('drag:leave', { el: _currentHover.el, data: _active.data });
+    _currentHover = null;
+  }
+}
+
+function handleEnd(e: MouseEvent | TouchEvent): void {
+  if (!_active) return;
+  const { clientX, clientY } = getPointer(e);
+
+  // Drop
+  if (_active.started) {
+    const hit = droppableAt(clientX, clientY);
+    if (hit) {
+      const accepted = hit.options.accept ? hit.options.accept(_active.data) : true;
+      if (accepted) {
+        hit.options.onDrop?.(hit.el, _active.data);
+        emit('drag:drop', { el: hit.el, data: _active.data });
+      }
+      if (hit.options.hoverClass) hit.el.classList.remove(hit.options.hoverClass);
+    }
+
+    const dragClass = _active.options.class || 'tx-dragging';
+    _active.el.classList.remove(dragClass);
+    _active.options.onDragEnd?.(_active.el, _active.data);
+    emit('drag:end', { el: _active.el, data: _active.data });
+  }
+
+  removeGhost(_active.ghost);
+  _active = null;
+  _currentHover = null;
+}
+
+// Ensure document-level listeners are attached exactly once.
+let _docListenersAttached = false;
+
+function ensureDocListeners(): void {
+  if (_docListenersAttached) return;
+  if (typeof document === 'undefined') return;
+  _docListenersAttached = true;
+
+  document.addEventListener('mousemove', handleMove);
+  document.addEventListener('mouseup', handleEnd);
+  document.addEventListener('touchmove', handleMove, { passive: true });
+  document.addEventListener('touchend', handleEnd);
+  document.addEventListener('touchcancel', handleEnd);
+}
+
+// ----------------------------------------------------------
+//  Public API
+// ----------------------------------------------------------
+
+/**
+ * Make an element draggable.
+ *
+ * Returns a `DraggableInstance` with a `destroy()` method to remove listeners.
+ */
+export function draggable(el: HTMLElement, options: DraggableOptions = {}): DraggableInstance {
+  ensureDocListeners();
+
+  el.classList.add('tx-draggable');
+
+  const handleEl = options.handle ? el.querySelector<HTMLElement>(options.handle) : el;
+  if (!handleEl) {
+    throw new Error(`Teryx draggable: handle "${options.handle}" not found inside element`);
+  }
+
+  const onPointerDown = (e: MouseEvent | TouchEvent) => {
+    // Only left mouse button or touch
+    if ('button' in e && (e as MouseEvent).button !== 0) return;
+
+    const { clientX, clientY } = getPointer(e);
+    const rect = el.getBoundingClientRect();
+
+    const ghost = options.ghost !== false ? createGhost(el) : null;
+    if (ghost) positionGhost(ghost, clientX, clientY, clientX - rect.left, clientY - rect.top);
+
+    _active = {
+      el,
+      data: options.data,
+      ghost,
+      offsetX: clientX - rect.left,
+      offsetY: clientY - rect.top,
+      options,
+      started: false,
+    };
+
+    e.preventDefault();
+  };
+
+  handleEl.addEventListener('mousedown', onPointerDown as EventListener);
+  handleEl.addEventListener('touchstart', onPointerDown as EventListener, { passive: false });
+
+  return {
+    el,
+    destroy() {
+      handleEl.removeEventListener('mousedown', onPointerDown as EventListener);
+      handleEl.removeEventListener('touchstart', onPointerDown as EventListener);
+      el.classList.remove('tx-draggable');
+    },
+  };
+}
+
+/**
+ * Make an element a drop target.
+ *
+ * Returns a `DroppableInstance` with a `destroy()` method to deregister.
+ */
+export function droppable(el: HTMLElement, options: DroppableOptions = {}): DroppableInstance {
+  ensureDocListeners();
+
+  el.classList.add('tx-droppable');
+
+  const entry = { el, options };
+  _droppables.add(entry);
+
+  return {
+    el,
+    destroy() {
+      _droppables.delete(entry);
+      el.classList.remove('tx-droppable');
+    },
+  };
+}
+
+// ----------------------------------------------------------
+//  Widget registration (declarative usage)
+// ----------------------------------------------------------
+
+registerWidget('draggable', (el, opts) => draggable(el, opts as unknown as DraggableOptions));
+registerWidget('droppable', (el, opts) => droppable(el, opts as unknown as DroppableOptions));

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -36,3 +36,4 @@ export { skeleton } from './skeleton';
 export { richEditor } from './rich-editor';
 export { tooltip, popover } from './tooltip';
 export { datePicker } from './datepicker';
+export { draggable, droppable } from './drag-drop';

--- a/styles/teryx.css
+++ b/styles/teryx.css
@@ -5214,3 +5214,167 @@ body.tx-drawer-open {
 .tx-datepicker-day-range-end {
   border-radius: 0 var(--tx-radius) var(--tx-radius) 0;
 }
+
+/* === Drag & Drop === */
+.tx-draggable {
+  cursor: grab;
+  user-select: none;
+}
+.tx-draggable:active {
+  cursor: grabbing;
+}
+.tx-dragging {
+  opacity: 0.4;
+}
+.tx-drag-ghost {
+  box-shadow: var(--tx-shadow-lg);
+  border-radius: var(--tx-radius);
+  background: var(--tx-bg);
+}
+.tx-droppable {
+  transition: outline var(--tx-transition);
+}
+.tx-drop-hover {
+  outline: 2px dashed var(--tx-primary);
+  outline-offset: 2px;
+  background: var(--tx-primary-light);
+}
+
+/* === Transfer List === */
+.tx-transfer {
+  display: flex;
+  align-items: stretch;
+  gap: var(--tx-space-3);
+  font-family: var(--tx-font);
+  font-size: var(--tx-font-size);
+}
+.tx-transfer-list {
+  flex: 1;
+  border: 1px solid var(--tx-border);
+  border-radius: var(--tx-radius);
+  background: var(--tx-bg);
+  display: flex;
+  flex-direction: column;
+  min-height: 260px;
+  max-height: 400px;
+}
+.tx-transfer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--tx-space-2) var(--tx-space-3);
+  border-bottom: 1px solid var(--tx-border);
+  background: var(--tx-bg-secondary);
+  border-radius: var(--tx-radius) var(--tx-radius) 0 0;
+}
+.tx-transfer-title {
+  font-weight: 600;
+  color: var(--tx-text);
+}
+.tx-transfer-count {
+  font-size: 0.75rem;
+  color: var(--tx-text-muted);
+  background: var(--tx-bg-tertiary);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--tx-radius-full);
+}
+.tx-transfer-search {
+  position: relative;
+  padding: var(--tx-space-2);
+  border-bottom: 1px solid var(--tx-border);
+}
+.tx-transfer-search-input {
+  width: 100%;
+  padding: var(--tx-space-1) var(--tx-space-2) var(--tx-space-1) calc(var(--tx-space-6) + 4px);
+  border: 1px solid var(--tx-border);
+  border-radius: var(--tx-radius-sm);
+  font-size: var(--tx-font-size);
+  background: var(--tx-bg);
+  color: var(--tx-text);
+  outline: none;
+  box-sizing: border-box;
+}
+.tx-transfer-search-input:focus {
+  border-color: var(--tx-border-focus);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tx-primary) 20%, transparent);
+}
+.tx-transfer-search-icon {
+  position: absolute;
+  left: calc(var(--tx-space-2) + var(--tx-space-2));
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--tx-text-muted);
+  pointer-events: none;
+  display: flex;
+}
+.tx-transfer-list-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--tx-space-1) 0;
+}
+.tx-transfer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--tx-space-2);
+  padding: var(--tx-space-1) var(--tx-space-3);
+  cursor: pointer;
+  transition: background var(--tx-transition);
+  color: var(--tx-text);
+}
+.tx-transfer-item:hover {
+  background: var(--tx-bg-secondary);
+}
+.tx-transfer-item-selected {
+  background: var(--tx-primary-light);
+}
+.tx-transfer-item-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.tx-transfer-checkbox {
+  accent-color: var(--tx-primary);
+  cursor: pointer;
+}
+.tx-transfer-item-label {
+  flex: 1;
+  user-select: none;
+}
+.tx-transfer-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--tx-space-6);
+  color: var(--tx-text-muted);
+  font-style: italic;
+}
+.tx-transfer-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tx-space-2);
+}
+.tx-transfer-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--tx-space-1) var(--tx-space-2);
+  border: 1px solid var(--tx-border);
+  border-radius: var(--tx-radius-sm);
+  background: var(--tx-bg);
+  cursor: pointer;
+  color: var(--tx-text-secondary);
+  transition:
+    background var(--tx-transition),
+    color var(--tx-transition),
+    border-color var(--tx-transition);
+}
+.tx-transfer-btn:hover:not([disabled]) {
+  background: var(--tx-primary);
+  color: var(--tx-text-inverse);
+  border-color: var(--tx-primary);
+}
+.tx-transfer-btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/tests/browser/drag-drop.spec.ts
+++ b/tests/browser/drag-drop.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, createWidget } from './helpers';
+
+test.describe('Drag & Drop', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+  });
+
+  test('draggable adds tx-draggable class', async ({ page }) => {
+    await createWidget(
+      page,
+      `
+      const el = document.createElement('div');
+      el.id = 'drag-el';
+      el.textContent = 'Drag me';
+      document.getElementById('target').appendChild(el);
+      Teryx.draggable(el, { data: 'hello' });
+    `,
+    );
+
+    await expect(page.locator('#drag-el')).toHaveClass(/tx-draggable/);
+  });
+
+  test('droppable adds tx-droppable class', async ({ page }) => {
+    await createWidget(
+      page,
+      `
+      const el = document.createElement('div');
+      el.id = 'drop-zone';
+      el.style.width = '200px';
+      el.style.height = '200px';
+      document.getElementById('target').appendChild(el);
+      Teryx.droppable(el, {});
+    `,
+    );
+
+    await expect(page.locator('#drop-zone')).toHaveClass(/tx-droppable/);
+  });
+
+  test('drag and drop fires onDrop callback', async ({ page }) => {
+    await createWidget(
+      page,
+      `
+      const dragEl = document.createElement('div');
+      dragEl.id = 'drag-item';
+      dragEl.style.width = '50px';
+      dragEl.style.height = '50px';
+      dragEl.style.position = 'absolute';
+      dragEl.style.left = '10px';
+      dragEl.style.top = '10px';
+      dragEl.textContent = 'Drag';
+      document.getElementById('target').appendChild(dragEl);
+
+      const dropEl = document.createElement('div');
+      dropEl.id = 'drop-target';
+      dropEl.style.width = '200px';
+      dropEl.style.height = '200px';
+      dropEl.style.position = 'absolute';
+      dropEl.style.left = '200px';
+      dropEl.style.top = '0px';
+      dropEl.textContent = 'Drop Here';
+      document.getElementById('target').appendChild(dropEl);
+
+      window.__dropped = false;
+      Teryx.draggable(dragEl, { data: { id: 1 } });
+      Teryx.droppable(dropEl, {
+        onDrop: (el, data) => { window.__dropped = data; }
+      });
+    `,
+    );
+
+    const drag = page.locator('#drag-item');
+    const drop = page.locator('#drop-target');
+
+    await drag.dragTo(drop);
+    await page.waitForTimeout(200);
+
+    const dropped = await page.evaluate(() => (window as any).__dropped);
+    expect(dropped).toEqual({ id: 1 });
+  });
+
+  test('destroy removes classes and stops drag', async ({ page }) => {
+    await createWidget(
+      page,
+      `
+      const el = document.createElement('div');
+      el.id = 'destroy-drag';
+      el.textContent = 'Drag me';
+      document.getElementById('target').appendChild(el);
+      window.__dragInst = Teryx.draggable(el, { data: 'test' });
+    `,
+    );
+
+    await expect(page.locator('#destroy-drag')).toHaveClass(/tx-draggable/);
+
+    await page.evaluate(() => (window as any).__dragInst.destroy());
+    await page.waitForTimeout(100);
+
+    const hasClass = await page.evaluate(() =>
+      document.getElementById('destroy-drag')!.classList.contains('tx-draggable'),
+    );
+    expect(hasClass).toBe(false);
+  });
+});

--- a/tests/widgets/drag-drop.test.ts
+++ b/tests/widgets/drag-drop.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { draggable, droppable } from '../../src/widgets/drag-drop';
+import { on, off } from '../../src/core';
+
+describe('Drag & Drop — draggable()', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.style.width = '100px';
+    container.style.height = '100px';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should add tx-draggable class to the element', () => {
+    draggable(container, { data: 'test' });
+    expect(container.classList.contains('tx-draggable')).toBe(true);
+  });
+
+  it('destroy() removes tx-draggable class', () => {
+    const inst = draggable(container, { data: 'test' });
+    inst.destroy();
+    expect(container.classList.contains('tx-draggable')).toBe(false);
+  });
+
+  it('should return the element via .el', () => {
+    const inst = draggable(container, { data: 42 });
+    expect(inst.el).toBe(container);
+  });
+
+  it('should fire onDragStart callback on mousedown+mousemove', () => {
+    const onStart = vi.fn();
+    draggable(container, { data: { id: 1 }, onDragStart: onStart });
+
+    container.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 10, clientY: 10, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 20, clientY: 20, bubbles: true }));
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledWith(container, { id: 1 });
+
+    // Clean up drag state
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 20, clientY: 20, bubbles: true }));
+  });
+
+  it('should fire onDragEnd callback on mouseup after drag', () => {
+    const onEnd = vi.fn();
+    draggable(container, { data: 'payload', onDragEnd: onEnd });
+
+    container.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 10, clientY: 10, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 25, clientY: 25, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 25, clientY: 25, bubbles: true }));
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledWith(container, 'payload');
+  });
+
+  it('should emit drag:start event on the event bus', () => {
+    const handler = vi.fn();
+    on('drag:start', handler);
+
+    draggable(container, { data: 'bus-test' });
+
+    container.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 5, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 15, clientY: 15, bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ data: 'bus-test' }));
+
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 15, clientY: 15, bubbles: true }));
+    off('drag:start', handler);
+  });
+
+  it('should emit drag:end event on the event bus', () => {
+    const handler = vi.fn();
+    on('drag:end', handler);
+
+    draggable(container, { data: 'end-bus' });
+
+    container.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 5, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 15, clientY: 15, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 15, clientY: 15, bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    off('drag:end', handler);
+  });
+
+  it('should throw if handle selector does not exist', () => {
+    expect(() => draggable(container, { handle: '.nonexistent' })).toThrow(/handle/);
+  });
+
+  it('should apply custom dragging class from options', () => {
+    draggable(container, { data: 'cls', class: 'my-drag' });
+
+    container.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 5, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 15, clientY: 15, bubbles: true }));
+
+    expect(container.classList.contains('my-drag')).toBe(true);
+
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 15, clientY: 15, bubbles: true }));
+    expect(container.classList.contains('my-drag')).toBe(false);
+  });
+});
+
+describe('Drag & Drop — droppable()', () => {
+  let dropZone: HTMLDivElement;
+
+  beforeEach(() => {
+    dropZone = document.createElement('div');
+    dropZone.style.width = '200px';
+    dropZone.style.height = '200px';
+    document.body.appendChild(dropZone);
+  });
+
+  afterEach(() => {
+    dropZone.remove();
+  });
+
+  it('should add tx-droppable class to the element', () => {
+    droppable(dropZone, {});
+    expect(dropZone.classList.contains('tx-droppable')).toBe(true);
+  });
+
+  it('destroy() removes tx-droppable class', () => {
+    const inst = droppable(dropZone, {});
+    inst.destroy();
+    expect(dropZone.classList.contains('tx-droppable')).toBe(false);
+  });
+
+  it('should return the element via .el', () => {
+    const inst = droppable(dropZone, {});
+    expect(inst.el).toBe(dropZone);
+  });
+
+  it('should fire onDrop when a draggable is dropped on it', () => {
+    const onDrop = vi.fn();
+    const dragEl = document.createElement('div');
+    dragEl.style.width = '50px';
+    dragEl.style.height = '50px';
+    document.body.appendChild(dragEl);
+
+    // Mock getBoundingClientRect for the drop zone
+    const rectSpy = vi.spyOn(dropZone, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      right: 200,
+      top: 0,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    draggable(dragEl, { data: { item: 'A' } });
+    droppable(dropZone, { onDrop });
+
+    // Simulate drag and drop
+    dragEl.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 25, clientY: 25, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 100, clientY: 100, bubbles: true }));
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect(onDrop).toHaveBeenCalledWith(dropZone, { item: 'A' });
+
+    rectSpy.mockRestore();
+    dragEl.remove();
+  });
+
+  it('should emit drag:drop event on the bus', () => {
+    const handler = vi.fn();
+    on('drag:drop', handler);
+
+    const dragEl = document.createElement('div');
+    document.body.appendChild(dragEl);
+
+    vi.spyOn(dropZone, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      right: 200,
+      top: 0,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    draggable(dragEl, { data: 'bus-drop' });
+    droppable(dropZone, {});
+
+    dragEl.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 5, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 50, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 50, clientY: 50, bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    off('drag:drop', handler);
+    dragEl.remove();
+  });
+
+  it('should reject drop when accept returns false', () => {
+    const onDrop = vi.fn();
+    const dragEl = document.createElement('div');
+    document.body.appendChild(dragEl);
+
+    vi.spyOn(dropZone, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      right: 200,
+      top: 0,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    draggable(dragEl, { data: 'rejected' });
+    droppable(dropZone, {
+      accept: () => false,
+      onDrop,
+    });
+
+    dragEl.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 5, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 50, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 50, clientY: 50, bubbles: true }));
+
+    expect(onDrop).not.toHaveBeenCalled();
+
+    dragEl.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `draggable(el, options)` and `droppable(el, options)` functions for generic drag-and-drop support
- Supports mouse and touch events, ghost clones, accept filtering, hover classes, and custom drag class
- Emits events on the Teryx event bus: `drag:start`, `drag:over`, `drag:drop`, `drag:end`
- Registers as declarative widgets (`data-tx-widget="draggable"` / `"droppable"`)
- Adds CSS styles for `.tx-draggable`, `.tx-dragging`, `.tx-drag-ghost`, `.tx-droppable`, `.tx-drop-hover`

## Test plan
- [x] 15 unit tests covering draggable class management, callbacks, event bus integration, accept filtering, custom classes, destroy cleanup
- [x] Browser test covering class application, drag-and-drop callback firing, destroy behavior
- [x] TypeScript type-check passes (`npx tsc --noEmit`)

Closes #2