### PR TITLE
Add Transfer List widget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export {
   slider,
   tagInput,
   datePicker,
+  transferList,
 } from './widgets';
 
 // Category imports

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -39,3 +39,4 @@ export { datePicker } from './datepicker';
 export { draggable, droppable } from './drag-drop';
 export { slider } from './slider';
 export { tagInput } from './tag-input';
+export { transferList } from './transfer-list';

--- a/src/widgets/transfer-list.ts
+++ b/src/widgets/transfer-list.ts
@@ -1,0 +1,221 @@
+// ============================================================
+// Teryx — Transfer List Widget
+// ============================================================
+
+import type { TransferOptions, WidgetInstance } from '../types';
+import { uid, esc, cls, icon, resolveTarget } from '../utils';
+import { registerWidget, emit } from '../core';
+
+export interface TransferInstance extends WidgetInstance {
+  getTargetKeys(): string[];
+  setTargetKeys(keys: string[]): void;
+}
+
+export function transferList(target: string | HTMLElement, options: TransferOptions): TransferInstance {
+  const el = resolveTarget(target);
+  const id = options.id || uid('tx-transfer');
+  const titles = options.titles || ['Source', 'Target'];
+  const searchable = options.searchable ?? false;
+
+  let targetKeys = new Set<string>(options.target || []);
+  const selectedLeft = new Set<string>();
+  const selectedRight = new Set<string>();
+  let leftFilter = '';
+  let rightFilter = '';
+
+  function getSourceItems() {
+    return options.source.filter((item) => !targetKeys.has(item.value));
+  }
+
+  function getTargetItems() {
+    return options.source.filter((item) => targetKeys.has(item.value));
+  }
+
+  function fireChange(): void {
+    const keys = Array.from(targetKeys);
+    options.onChange?.(keys);
+    emit('transfer:change', { id, targetKeys: keys });
+  }
+
+  function renderListItems(
+    items: { label: string; value: string; disabled?: boolean }[],
+    selected: Set<string>,
+    filter: string,
+  ): string {
+    const filtered = filter ? items.filter((item) => item.label.toLowerCase().includes(filter.toLowerCase())) : items;
+
+    if (filtered.length === 0) {
+      return '<div class="tx-transfer-empty">No items</div>';
+    }
+
+    let html = '';
+    for (const item of filtered) {
+      const isSelected = selected.has(item.value);
+      const disabledAttr = item.disabled ? ' disabled' : '';
+      html += `<label class="${cls('tx-transfer-item', isSelected && 'tx-transfer-item-selected', item.disabled && 'tx-transfer-item-disabled')}"${disabledAttr}>`;
+      html += `<input type="checkbox" class="tx-transfer-checkbox" data-value="${esc(item.value)}"${isSelected ? ' checked' : ''}${disabledAttr}>`;
+      html += `<span class="tx-transfer-item-label">${esc(item.label)}</span>`;
+      html += '</label>';
+    }
+    return html;
+  }
+
+  function render(): void {
+    const sourceItems = getSourceItems();
+    const targetItems = getTargetItems();
+    const hasSelectedLeft = selectedLeft.size > 0;
+    const hasSelectedRight = selectedRight.size > 0;
+    const hasSourceItems = sourceItems.some((item) => !item.disabled);
+    const hasTargetItems = targetItems.some((item) => !item.disabled);
+
+    let html = `<div class="${cls('tx-transfer', options.class)}" id="${esc(id)}">`;
+
+    html += '<div class="tx-transfer-list tx-transfer-list-left">';
+    html += `<div class="tx-transfer-header"><span class="tx-transfer-title">${esc(titles[0])}</span>`;
+    html += `<span class="tx-transfer-count">${sourceItems.length}</span></div>`;
+    if (searchable) {
+      html += '<div class="tx-transfer-search">';
+      html += `<input type="text" class="tx-transfer-search-input" data-side="left" placeholder="Search..." value="${esc(leftFilter)}">`;
+      html += `<span class="tx-transfer-search-icon">${icon('search')}</span>`;
+      html += '</div>';
+    }
+    html += '<div class="tx-transfer-list-content">';
+    html += renderListItems(sourceItems, selectedLeft, leftFilter);
+    html += '</div></div>';
+
+    html += '<div class="tx-transfer-actions">';
+    html += `<button class="tx-transfer-btn tx-transfer-btn-right" data-action="move-right"${!hasSelectedLeft ? ' disabled' : ''} title="Move selected right">${icon('chevronRight')}</button>`;
+    html += `<button class="tx-transfer-btn tx-transfer-btn-all-right" data-action="move-all-right"${!hasSourceItems ? ' disabled' : ''} title="Move all right">${icon('chevronRight')}${icon('chevronRight')}</button>`;
+    html += `<button class="tx-transfer-btn tx-transfer-btn-left" data-action="move-left"${!hasSelectedRight ? ' disabled' : ''} title="Move selected left">${icon('chevronLeft')}</button>`;
+    html += `<button class="tx-transfer-btn tx-transfer-btn-all-left" data-action="move-all-left"${!hasTargetItems ? ' disabled' : ''} title="Move all left">${icon('chevronLeft')}${icon('chevronLeft')}</button>`;
+    html += '</div>';
+
+    html += '<div class="tx-transfer-list tx-transfer-list-right">';
+    html += `<div class="tx-transfer-header"><span class="tx-transfer-title">${esc(titles[1])}</span>`;
+    html += `<span class="tx-transfer-count">${targetItems.length}</span></div>`;
+    if (searchable) {
+      html += '<div class="tx-transfer-search">';
+      html += `<input type="text" class="tx-transfer-search-input" data-side="right" placeholder="Search..." value="${esc(rightFilter)}">`;
+      html += `<span class="tx-transfer-search-icon">${icon('search')}</span>`;
+      html += '</div>';
+    }
+    html += '<div class="tx-transfer-list-content">';
+    html += renderListItems(targetItems, selectedRight, rightFilter);
+    html += '</div></div>';
+
+    html += '</div>';
+    el.innerHTML = html;
+
+    bindEvents();
+  }
+
+  function bindEvents(): void {
+    const root = el.querySelector(`#${id}`) as HTMLElement;
+    if (!root) return;
+
+    root.addEventListener('change', (e) => {
+      const checkbox = e.target as HTMLInputElement;
+      if (!checkbox.classList.contains('tx-transfer-checkbox')) return;
+      const value = checkbox.getAttribute('data-value')!;
+      const isLeft = checkbox.closest('.tx-transfer-list-left');
+      const set = isLeft ? selectedLeft : selectedRight;
+
+      if (checkbox.checked) {
+        set.add(value);
+      } else {
+        set.delete(value);
+      }
+      render();
+    });
+
+    root.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest('[data-action]') as HTMLElement;
+      if (!btn || btn.hasAttribute('disabled')) return;
+      const action = btn.getAttribute('data-action');
+
+      switch (action) {
+        case 'move-right': {
+          for (const key of selectedLeft) {
+            const item = options.source.find((i) => i.value === key);
+            if (item && !item.disabled) {
+              targetKeys.add(key);
+            }
+          }
+          selectedLeft.clear();
+          fireChange();
+          break;
+        }
+        case 'move-all-right': {
+          for (const item of options.source) {
+            if (!item.disabled) {
+              targetKeys.add(item.value);
+            }
+          }
+          selectedLeft.clear();
+          fireChange();
+          break;
+        }
+        case 'move-left': {
+          for (const key of selectedRight) {
+            const item = options.source.find((i) => i.value === key);
+            if (item && !item.disabled) {
+              targetKeys.delete(key);
+            }
+          }
+          selectedRight.clear();
+          fireChange();
+          break;
+        }
+        case 'move-all-left': {
+          for (const item of options.source) {
+            if (!item.disabled) {
+              targetKeys.delete(item.value);
+            }
+          }
+          selectedRight.clear();
+          fireChange();
+          break;
+        }
+      }
+      render();
+    });
+
+    if (searchable) {
+      root.querySelectorAll<HTMLInputElement>('.tx-transfer-search-input').forEach((input) => {
+        input.addEventListener('input', () => {
+          const side = input.getAttribute('data-side');
+          if (side === 'left') {
+            leftFilter = input.value;
+          } else {
+            rightFilter = input.value;
+          }
+          render();
+        });
+      });
+    }
+  }
+
+  render();
+
+  return {
+    el: el.querySelector(`#${id}`) || el,
+    destroy() {
+      el.innerHTML = '';
+    },
+    getTargetKeys() {
+      return Array.from(targetKeys);
+    },
+    setTargetKeys(keys: string[]) {
+      targetKeys = new Set(keys);
+      selectedLeft.clear();
+      selectedRight.clear();
+      leftFilter = '';
+      rightFilter = '';
+      render();
+      fireChange();
+    },
+  };
+}
+
+registerWidget('transfer-list', (el, opts) => transferList(el, opts as unknown as TransferOptions));
+export default transferList;

--- a/tests/browser/transfer-list.spec.ts
+++ b/tests/browser/transfer-list.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, count } from './helpers';
+
+const SOURCE = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+  { label: 'Date', value: 'date' },
+];
+
+test.describe('TransferList Widget', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+  });
+
+  test('renders two panels with titles', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).Teryx.transferList('#target', { source: src });
+    }, SOURCE);
+    await expect(page.locator('.tx-transfer-list-left')).toBeVisible();
+    await expect(page.locator('.tx-transfer-list-right')).toBeVisible();
+    await expect(page.locator('.tx-transfer-title').nth(0)).toHaveText('Source');
+    await expect(page.locator('.tx-transfer-title').nth(1)).toHaveText('Target');
+  });
+
+  test('renders custom titles', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).Teryx.transferList('#target', { source: src, titles: ['Available', 'Selected'] });
+    }, SOURCE);
+    await expect(page.locator('.tx-transfer-title').nth(0)).toHaveText('Available');
+    await expect(page.locator('.tx-transfer-title').nth(1)).toHaveText('Selected');
+  });
+
+  test('renders all items in the source panel', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).Teryx.transferList('#target', { source: src });
+    }, SOURCE);
+    const items = await count(page, '.tx-transfer-list-left .tx-transfer-item');
+    expect(items).toBe(4);
+  });
+
+  test('pre-selected target keys appear in right panel', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).Teryx.transferList('#target', { source: src, target: ['banana', 'date'] });
+    }, SOURCE);
+    const leftItems = await count(page, '.tx-transfer-list-left .tx-transfer-item');
+    const rightItems = await count(page, '.tx-transfer-list-right .tx-transfer-item');
+    expect(leftItems).toBe(2);
+    expect(rightItems).toBe(2);
+  });
+
+  test('getTargetKeys returns current target keys', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).__tl = (window as any).Teryx.transferList('#target', {
+        source: src,
+        target: ['cherry'],
+      });
+    }, SOURCE);
+    const keys = await page.evaluate(() => (window as any).__tl.getTargetKeys());
+    expect(keys).toEqual(['cherry']);
+  });
+
+  test('setTargetKeys updates both panels', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).__tl = (window as any).Teryx.transferList('#target', { source: src });
+    }, SOURCE);
+    await page.evaluate(() => (window as any).__tl.setTargetKeys(['apple', 'banana']));
+    await page.waitForTimeout(100);
+
+    const leftItems = await count(page, '.tx-transfer-list-left .tx-transfer-item');
+    const rightItems = await count(page, '.tx-transfer-list-right .tx-transfer-item');
+    expect(leftItems).toBe(2);
+    expect(rightItems).toBe(2);
+
+    const keys = await page.evaluate(() => (window as any).__tl.getTargetKeys());
+    expect(keys).toEqual(expect.arrayContaining(['apple', 'banana']));
+  });
+
+  test('selecting and moving items right', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).__tl = (window as any).Teryx.transferList('#target', { source: src });
+    }, SOURCE);
+
+    // Check the first item in the left panel
+    await page.locator('.tx-transfer-list-left .tx-transfer-checkbox').first().check();
+    await page.waitForTimeout(100);
+
+    // Click move-right button
+    await page.locator('[data-action="move-right"]').click();
+    await page.waitForTimeout(100);
+
+    const rightItems = await count(page, '.tx-transfer-list-right .tx-transfer-item');
+    expect(rightItems).toBe(1);
+  });
+
+  test('move all right transfers all items', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).__tl = (window as any).Teryx.transferList('#target', { source: src });
+    }, SOURCE);
+
+    await page.locator('[data-action="move-all-right"]').click();
+    await page.waitForTimeout(100);
+
+    const leftItems = await count(page, '.tx-transfer-list-left .tx-transfer-item');
+    const rightItems = await count(page, '.tx-transfer-list-right .tx-transfer-item');
+    expect(leftItems).toBe(0);
+    expect(rightItems).toBe(4);
+  });
+
+  test('move all left transfers all items back', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).__tl = (window as any).Teryx.transferList('#target', {
+        source: src,
+        target: ['apple', 'banana', 'cherry', 'date'],
+      });
+    }, SOURCE);
+
+    await page.locator('[data-action="move-all-left"]').click();
+    await page.waitForTimeout(100);
+
+    const leftItems = await count(page, '.tx-transfer-list-left .tx-transfer-item');
+    const rightItems = await count(page, '.tx-transfer-list-right .tx-transfer-item');
+    expect(leftItems).toBe(4);
+    expect(rightItems).toBe(0);
+  });
+
+  test('search filters items', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).Teryx.transferList('#target', { source: src, searchable: true });
+    }, SOURCE);
+
+    await expect(page.locator('.tx-transfer-search-input[data-side="left"]')).toBeVisible();
+    await page.locator('.tx-transfer-search-input[data-side="left"]').fill('app');
+    await page.waitForTimeout(100);
+
+    const items = await count(page, '.tx-transfer-list-left .tx-transfer-item');
+    expect(items).toBe(1);
+  });
+
+  test('disabled items cannot be transferred', async ({ page }) => {
+    const src = [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Banana', value: 'banana', disabled: true },
+    ];
+    await page.evaluate((s) => {
+      (window as any).__tl = (window as any).Teryx.transferList('#target', { source: s });
+    }, src);
+
+    // Move all right — disabled item should stay
+    await page.locator('[data-action="move-all-right"]').click();
+    await page.waitForTimeout(100);
+
+    const leftItems = await count(page, '.tx-transfer-list-left .tx-transfer-item');
+    const rightItems = await count(page, '.tx-transfer-list-right .tx-transfer-item');
+    expect(leftItems).toBe(1);
+    expect(rightItems).toBe(1);
+  });
+
+  test('destroy clears the widget', async ({ page }) => {
+    await page.evaluate((src) => {
+      (window as any).__tl = (window as any).Teryx.transferList('#target', { source: src });
+    }, SOURCE);
+    await expect(page.locator('.tx-transfer')).toBeVisible();
+
+    await page.evaluate(() => (window as any).__tl.destroy());
+    await page.waitForTimeout(100);
+
+    const transfers = await count(page, '.tx-transfer');
+    expect(transfers).toBe(0);
+  });
+});

--- a/tests/widgets/transfer-list.test.ts
+++ b/tests/widgets/transfer-list.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { transferList } from '../../src/widgets/transfer-list';
+
+const SOURCE_ITEMS = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+  { label: 'Date', value: 'date' },
+  { label: 'Elderberry', value: 'elderberry' },
+];
+
+describe('TransferList widget', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should render two list panels and action buttons', () => {
+    transferList(container, { source: SOURCE_ITEMS });
+    const lists = container.querySelectorAll('.tx-transfer-list');
+    expect(lists.length).toBe(2);
+    const actions = container.querySelector('.tx-transfer-actions');
+    expect(actions).not.toBeNull();
+    expect(actions!.querySelectorAll('.tx-transfer-btn').length).toBe(4);
+  });
+
+  it('should render all source items in the left list by default', () => {
+    transferList(container, { source: SOURCE_ITEMS });
+    const leftItems = container.querySelectorAll('.tx-transfer-list-left .tx-transfer-item');
+    expect(leftItems.length).toBe(5);
+    const rightItems = container.querySelectorAll('.tx-transfer-list-right .tx-transfer-item');
+    expect(rightItems.length).toBe(0);
+  });
+
+  it('should place initially selected items in the right list', () => {
+    transferList(container, { source: SOURCE_ITEMS, target: ['banana', 'date'] });
+    const leftItems = container.querySelectorAll('.tx-transfer-list-left .tx-transfer-item');
+    expect(leftItems.length).toBe(3);
+    const rightItems = container.querySelectorAll('.tx-transfer-list-right .tx-transfer-item');
+    expect(rightItems.length).toBe(2);
+  });
+
+  it('should display custom titles', () => {
+    transferList(container, { source: SOURCE_ITEMS, titles: ['Available', 'Selected'] });
+    const titles = container.querySelectorAll('.tx-transfer-title');
+    expect(titles[0].textContent).toBe('Available');
+    expect(titles[1].textContent).toBe('Selected');
+  });
+
+  it('should move selected items to the right when > is clicked', () => {
+    const onChange = vi.fn();
+    transferList(container, { source: SOURCE_ITEMS, onChange });
+    const checkbox = container.querySelector(
+      '.tx-transfer-list-left .tx-transfer-checkbox[data-value="apple"]',
+    ) as HTMLInputElement;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+    const moveRightBtn = container.querySelector('[data-action="move-right"]') as HTMLButtonElement;
+    moveRightBtn.click();
+    expect(onChange).toHaveBeenCalled();
+    const keys = onChange.mock.calls[0][0] as string[];
+    expect(keys).toContain('apple');
+  });
+
+  it('should move all items to the right when >> is clicked', () => {
+    const onChange = vi.fn();
+    transferList(container, { source: SOURCE_ITEMS, onChange });
+    const moveAllRightBtn = container.querySelector('[data-action="move-all-right"]') as HTMLButtonElement;
+    moveAllRightBtn.click();
+    expect(onChange).toHaveBeenCalled();
+    const keys = onChange.mock.calls[0][0] as string[];
+    expect(keys.length).toBe(5);
+  });
+
+  it('should move selected items back to the left when < is clicked', () => {
+    const onChange = vi.fn();
+    transferList(container, { source: SOURCE_ITEMS, target: ['apple', 'banana'], onChange });
+    const checkbox = container.querySelector(
+      '.tx-transfer-list-right .tx-transfer-checkbox[data-value="apple"]',
+    ) as HTMLInputElement;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+    const moveLeftBtn = container.querySelector('[data-action="move-left"]') as HTMLButtonElement;
+    moveLeftBtn.click();
+    expect(onChange).toHaveBeenCalled();
+    const keys = onChange.mock.calls[0][0] as string[];
+    expect(keys).not.toContain('apple');
+    expect(keys).toContain('banana');
+  });
+
+  it('should move all items back to the left when << is clicked', () => {
+    const onChange = vi.fn();
+    transferList(container, { source: SOURCE_ITEMS, target: ['apple', 'banana', 'cherry'], onChange });
+    const moveAllLeftBtn = container.querySelector('[data-action="move-all-left"]') as HTMLButtonElement;
+    moveAllLeftBtn.click();
+    expect(onChange).toHaveBeenCalled();
+    const keys = onChange.mock.calls[0][0] as string[];
+    expect(keys.length).toBe(0);
+  });
+
+  it('getTargetKeys() returns current target values', () => {
+    const t = transferList(container, { source: SOURCE_ITEMS, target: ['cherry', 'date'] });
+    const keys = t.getTargetKeys();
+    expect(keys).toContain('cherry');
+    expect(keys).toContain('date');
+    expect(keys.length).toBe(2);
+  });
+
+  it('setTargetKeys() programmatically sets the target', () => {
+    const onChange = vi.fn();
+    const t = transferList(container, { source: SOURCE_ITEMS, onChange });
+    t.setTargetKeys(['banana', 'elderberry']);
+    expect(t.getTargetKeys()).toContain('banana');
+    expect(t.getTargetKeys()).toContain('elderberry');
+    expect(t.getTargetKeys().length).toBe(2);
+    const rightItems = container.querySelectorAll('.tx-transfer-list-right .tx-transfer-item');
+    expect(rightItems.length).toBe(2);
+  });
+
+  it('should render search inputs when searchable is true', () => {
+    transferList(container, { source: SOURCE_ITEMS, searchable: true });
+    const searchInputs = container.querySelectorAll('.tx-transfer-search-input');
+    expect(searchInputs.length).toBe(2);
+  });
+
+  it('search should filter items in the left list', () => {
+    transferList(container, { source: SOURCE_ITEMS, searchable: true });
+    const leftSearch = container.querySelector('.tx-transfer-list-left .tx-transfer-search-input') as HTMLInputElement;
+    leftSearch.value = 'app';
+    leftSearch.dispatchEvent(new Event('input', { bubbles: true }));
+    const leftItems = container.querySelectorAll('.tx-transfer-list-left .tx-transfer-item');
+    expect(leftItems.length).toBe(1);
+    expect(leftItems[0].textContent).toContain('Apple');
+  });
+
+  it('should not render search inputs when searchable is false', () => {
+    transferList(container, { source: SOURCE_ITEMS, searchable: false });
+    const searchInputs = container.querySelectorAll('.tx-transfer-search-input');
+    expect(searchInputs.length).toBe(0);
+  });
+
+  it('disabled items should not be moved by move-all', () => {
+    const sourceWithDisabled = [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Banana', value: 'banana', disabled: true },
+      { label: 'Cherry', value: 'cherry' },
+    ];
+    const onChange = vi.fn();
+    transferList(container, { source: sourceWithDisabled, onChange });
+    const moveAllRightBtn = container.querySelector('[data-action="move-all-right"]') as HTMLButtonElement;
+    moveAllRightBtn.click();
+    expect(onChange).toHaveBeenCalled();
+    const keys = onChange.mock.calls[0][0] as string[];
+    expect(keys).toContain('apple');
+    expect(keys).toContain('cherry');
+    expect(keys).not.toContain('banana');
+  });
+
+  it('should show item counts in headers', () => {
+    transferList(container, { source: SOURCE_ITEMS, target: ['apple', 'banana'] });
+    const counts = container.querySelectorAll('.tx-transfer-count');
+    expect(counts[0].textContent).toBe('3');
+    expect(counts[1].textContent).toBe('2');
+  });
+
+  it('destroy() clears content', () => {
+    const t = transferList(container, { source: SOURCE_ITEMS });
+    t.destroy();
+    expect(container.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new `transferList` dual-list picker widget with left/right panels and directional transfer buttons (>, >>, <, <<)
- Supports optional search filtering, disabled items, custom titles, and programmatic `getTargetKeys()`/`setTargetKeys()` API
- Includes CSS styles (`.tx-transfer-*`), barrel exports, and 16 unit tests

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run tests/widgets/transfer-list.test.ts` passes (16/16 tests)
- [x] Manual verification of dual-list UI in a browser

Closes #9