### PR TITLE
Implement Pivot Grid widget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export {
   transferList,
   kanban,
   lightbox,
+  pivotGrid,
 } from './widgets';
 
 // Category imports

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -42,3 +42,4 @@ export { tagInput } from './tag-input';
 export { transferList } from './transfer-list';
 export { kanban } from './kanban';
 export { lightbox } from './lightbox';
+export { pivotGrid } from './pivot-grid';

--- a/src/widgets/pivot-grid.ts
+++ b/src/widgets/pivot-grid.ts
@@ -1,0 +1,423 @@
+// ============================================================
+// Teryx — Pivot Grid Widget
+// ============================================================
+
+import type { PivotOptions, WidgetInstance } from '../types';
+import { uid, esc, cls, resolveTarget } from '../utils';
+import { registerWidget, emit } from '../core';
+
+type AggFn = 'sum' | 'avg' | 'count' | 'min' | 'max';
+type Row = Record<string, unknown>;
+
+export interface PivotInstance extends WidgetInstance {
+  refresh(data: Row[]): void;
+  getAggregatedData(): Record<string, unknown>[];
+}
+
+function aggregate(values: number[], fn: AggFn): number {
+  if (values.length === 0) return 0;
+  switch (fn) {
+    case 'sum':
+      return values.reduce((a, b) => a + b, 0);
+    case 'avg':
+      return values.reduce((a, b) => a + b, 0) / values.length;
+    case 'count':
+      return values.length;
+    case 'min':
+      return Math.min(...values);
+    case 'max':
+      return Math.max(...values);
+  }
+}
+
+function groupKey(row: Row, fields: string[]): string {
+  return fields.map((f) => String(row[f] ?? '')).join('|||');
+}
+
+function uniqueSorted(data: Row[], field: string): string[] {
+  const set = new Set<string>();
+  for (const row of data) set.add(String(row[field] ?? ''));
+  return Array.from(set).sort();
+}
+
+interface PivotCell {
+  rowKey: string;
+  colKey: string;
+  values: Map<string, number>;
+}
+
+function buildPivot(
+  data: Row[],
+  rowFields: string[],
+  colFields: string[],
+  valueFields: { field: string; aggregate: AggFn }[],
+): {
+  rowKeys: string[];
+  colKeys: string[];
+  cells: Map<string, PivotCell>;
+  rowTotals: Map<string, Map<string, number>>;
+  colTotals: Map<string, Map<string, number>>;
+  grandTotals: Map<string, number>;
+  rowLabels: Map<string, string[]>;
+  colLabels: Map<string, string[]>;
+} {
+  const rowKeySet = new Set<string>();
+  const colKeySet = new Set<string>();
+  const buckets = new Map<string, Map<string, number[]>>();
+
+  for (const row of data) {
+    const rk = groupKey(row, rowFields);
+    const ck = colFields.length > 0 ? groupKey(row, colFields) : '__all__';
+    rowKeySet.add(rk);
+    colKeySet.add(ck);
+
+    const cellKey = `${rk}::${ck}`;
+    if (!buckets.has(cellKey)) {
+      buckets.set(cellKey, new Map());
+    }
+    const bucket = buckets.get(cellKey)!;
+    for (const vf of valueFields) {
+      const val = Number(row[vf.field]) || 0;
+      if (!bucket.has(vf.field)) bucket.set(vf.field, []);
+      bucket.get(vf.field)!.push(val);
+    }
+  }
+
+  const rowKeys = Array.from(rowKeySet).sort();
+  const colKeys = Array.from(colKeySet).sort();
+
+  const cells = new Map<string, PivotCell>();
+  for (const [cellKey, bucket] of buckets) {
+    const [rk, ck] = cellKey.split('::');
+    const values = new Map<string, number>();
+    for (const vf of valueFields) {
+      const raw = bucket.get(vf.field) || [];
+      values.set(vf.field, aggregate(raw, vf.aggregate));
+    }
+    cells.set(cellKey, { rowKey: rk, colKey: ck, values });
+  }
+
+  // Row totals
+  const rowTotals = new Map<string, Map<string, number>>();
+  for (const rk of rowKeys) {
+    const totals = new Map<string, number>();
+    for (const vf of valueFields) {
+      const vals: number[] = [];
+      for (const ck of colKeys) {
+        const cell = cells.get(`${rk}::${ck}`);
+        if (cell) vals.push(cell.values.get(vf.field) || 0);
+      }
+      totals.set(vf.field, aggregate(vals, vf.aggregate === 'avg' ? 'avg' : 'sum'));
+    }
+    rowTotals.set(rk, totals);
+  }
+
+  // Column totals
+  const colTotals = new Map<string, Map<string, number>>();
+  for (const ck of colKeys) {
+    const totals = new Map<string, number>();
+    for (const vf of valueFields) {
+      const vals: number[] = [];
+      for (const rk of rowKeys) {
+        const cell = cells.get(`${rk}::${ck}`);
+        if (cell) vals.push(cell.values.get(vf.field) || 0);
+      }
+      totals.set(vf.field, aggregate(vals, vf.aggregate === 'avg' ? 'avg' : 'sum'));
+    }
+    colTotals.set(ck, totals);
+  }
+
+  // Grand totals
+  const grandTotals = new Map<string, number>();
+  for (const vf of valueFields) {
+    const vals: number[] = [];
+    for (const rk of rowKeys) {
+      const rt = rowTotals.get(rk);
+      if (rt) vals.push(rt.get(vf.field) || 0);
+    }
+    grandTotals.set(vf.field, aggregate(vals, vf.aggregate === 'avg' ? 'avg' : 'sum'));
+  }
+
+  // Label maps
+  const rowLabels = new Map<string, string[]>();
+  for (const rk of rowKeys) {
+    rowLabels.set(rk, rk.split('|||'));
+  }
+  const colLabels = new Map<string, string[]>();
+  for (const ck of colKeys) {
+    colLabels.set(ck, ck.split('|||'));
+  }
+
+  return { rowKeys, colKeys, cells, rowTotals, colTotals, grandTotals, rowLabels, colLabels };
+}
+
+function formatNumber(val: number): string {
+  return Number.isInteger(val) ? String(val) : val.toFixed(2);
+}
+
+export function pivotGrid(target: string | HTMLElement, options: PivotOptions): PivotInstance {
+  const el = resolveTarget(target);
+  const id = options.id || uid('tx-pivot');
+  const rowFields = options.rows;
+  const colFields = options.columns;
+  const valueFields = options.values;
+
+  let currentData: Row[] = [];
+  const collapsed = new Set<string>();
+
+  function render(): void {
+    const pivot = buildPivot(currentData, rowFields, colFields, valueFields);
+    const hasColFields = colFields.length > 0 && pivot.colKeys[0] !== '__all__';
+    const valueCount = valueFields.length;
+
+    let html = `<div class="${cls('tx-pivot', options.class)}" id="${esc(id)}">`;
+    html += '<table class="tx-pivot-table">';
+
+    // Header
+    html += '<thead>';
+
+    // Column field headers
+    if (hasColFields) {
+      html += '<tr class="tx-pivot-header">';
+      html += `<th class="tx-pivot-corner" colspan="${rowFields.length}"></th>`;
+      for (const ck of pivot.colKeys) {
+        const labels = pivot.colLabels.get(ck)!;
+        html += `<th class="tx-pivot-col-header" colspan="${valueCount}">${labels.map((l) => esc(l)).join(' / ')}</th>`;
+      }
+      html += `<th class="tx-pivot-total-header" colspan="${valueCount}">Grand Total</th>`;
+      html += '</tr>';
+    }
+
+    // Value field headers
+    html += '<tr class="tx-pivot-header tx-pivot-value-header">';
+    for (const rf of rowFields) {
+      html += `<th class="tx-pivot-row-field">${esc(rf)}</th>`;
+    }
+    if (hasColFields) {
+      for (const _ck of pivot.colKeys) {
+        for (const vf of valueFields) {
+          html += `<th class="tx-pivot-value-field">${esc(vf.field)} (${esc(vf.aggregate)})</th>`;
+        }
+      }
+    } else {
+      for (const vf of valueFields) {
+        html += `<th class="tx-pivot-value-field">${esc(vf.field)} (${esc(vf.aggregate)})</th>`;
+      }
+    }
+    html += `<th class="tx-pivot-value-field tx-pivot-total-col">Total</th>`.repeat(valueCount);
+    html += '</tr>';
+    html += '</thead>';
+
+    // Body
+    html += '<tbody>';
+
+    // Group by first row field for expandable groups
+    if (rowFields.length > 1) {
+      const firstFieldValues = uniqueSorted(currentData, rowFields[0]);
+      for (const groupVal of firstFieldValues) {
+        const isCollapsed = collapsed.has(groupVal);
+        const groupRows = pivot.rowKeys.filter((rk) => rk.startsWith(groupVal + '|||') || rk === groupVal);
+
+        // Group header row
+        html += `<tr class="tx-pivot-group-row" data-group="${esc(groupVal)}">`;
+        html += `<td class="tx-pivot-group-cell" colspan="${rowFields.length}">`;
+        html += `<span class="tx-pivot-toggle">${isCollapsed ? '&#9654;' : '&#9660;'}</span> `;
+        html += `${esc(groupVal)}`;
+        html += '</td>';
+
+        // Group subtotals
+        const groupSubtotals = new Map<string, Map<string, number>>();
+        if (hasColFields) {
+          for (const ck of pivot.colKeys) {
+            const totals = new Map<string, number>();
+            for (const vf of valueFields) {
+              const vals: number[] = [];
+              for (const rk of groupRows) {
+                const cell = pivot.cells.get(`${rk}::${ck}`);
+                if (cell) vals.push(cell.values.get(vf.field) || 0);
+              }
+              totals.set(vf.field, aggregate(vals, vf.aggregate === 'avg' ? 'avg' : 'sum'));
+            }
+            groupSubtotals.set(ck, totals);
+          }
+          for (const ck of pivot.colKeys) {
+            const totals = groupSubtotals.get(ck)!;
+            for (const vf of valueFields) {
+              html += `<td class="tx-pivot-cell tx-pivot-subtotal">${formatNumber(totals.get(vf.field) || 0)}</td>`;
+            }
+          }
+        } else {
+          for (const vf of valueFields) {
+            const vals: number[] = [];
+            for (const rk of groupRows) {
+              const cell = pivot.cells.get(`${rk}::__all__`);
+              if (cell) vals.push(cell.values.get(vf.field) || 0);
+            }
+            html += `<td class="tx-pivot-cell tx-pivot-subtotal">${formatNumber(aggregate(vals, vf.aggregate === 'avg' ? 'avg' : 'sum'))}</td>`;
+          }
+        }
+
+        // Group row totals
+        for (const vf of valueFields) {
+          const vals: number[] = [];
+          for (const rk of groupRows) {
+            const rt = pivot.rowTotals.get(rk);
+            if (rt) vals.push(rt.get(vf.field) || 0);
+          }
+          html += `<td class="tx-pivot-cell tx-pivot-total">${formatNumber(aggregate(vals, vf.aggregate === 'avg' ? 'avg' : 'sum'))}</td>`;
+        }
+        html += '</tr>';
+
+        // Detail rows
+        if (!isCollapsed) {
+          for (const rk of groupRows) {
+            html += renderDataRow(rk, pivot, hasColFields);
+          }
+        }
+      }
+    } else {
+      for (const rk of pivot.rowKeys) {
+        html += renderDataRow(rk, pivot, hasColFields);
+      }
+    }
+
+    html += '</tbody>';
+
+    // Footer — Grand totals
+    html += '<tfoot>';
+    html += '<tr class="tx-pivot-grand-total-row">';
+    html += `<td class="tx-pivot-grand-total-label" colspan="${rowFields.length}">Grand Total</td>`;
+    if (hasColFields) {
+      for (const ck of pivot.colKeys) {
+        const totals = pivot.colTotals.get(ck)!;
+        for (const vf of valueFields) {
+          html += `<td class="tx-pivot-cell tx-pivot-grand-total">${formatNumber(totals.get(vf.field) || 0)}</td>`;
+        }
+      }
+    } else {
+      for (const vf of valueFields) {
+        html += `<td class="tx-pivot-cell tx-pivot-grand-total">${formatNumber(pivot.grandTotals.get(vf.field) || 0)}</td>`;
+      }
+    }
+    for (const vf of valueFields) {
+      html += `<td class="tx-pivot-cell tx-pivot-grand-total">${formatNumber(pivot.grandTotals.get(vf.field) || 0)}</td>`;
+    }
+    html += '</tr>';
+    html += '</tfoot>';
+
+    html += '</table></div>';
+    el.innerHTML = html;
+
+    bindEvents();
+  }
+
+  function renderDataRow(rk: string, pivot: ReturnType<typeof buildPivot>, hasColFields: boolean): string {
+    const labels = pivot.rowLabels.get(rk)!;
+    let html = '<tr class="tx-pivot-data-row">';
+    for (const label of labels) {
+      html += `<td class="tx-pivot-row-label">${esc(label)}</td>`;
+    }
+
+    if (hasColFields) {
+      for (const ck of pivot.colKeys) {
+        const cell = pivot.cells.get(`${rk}::${ck}`);
+        for (const vf of valueFields) {
+          const val = cell ? cell.values.get(vf.field) || 0 : 0;
+          html += `<td class="tx-pivot-cell">${formatNumber(val)}</td>`;
+        }
+      }
+    } else {
+      const cell = pivot.cells.get(`${rk}::__all__`);
+      for (const vf of valueFields) {
+        const val = cell ? cell.values.get(vf.field) || 0 : 0;
+        html += `<td class="tx-pivot-cell">${formatNumber(val)}</td>`;
+      }
+    }
+
+    // Row total
+    const rt = pivot.rowTotals.get(rk);
+    for (const vf of valueFields) {
+      const val = rt ? rt.get(vf.field) || 0 : 0;
+      html += `<td class="tx-pivot-cell tx-pivot-total">${formatNumber(val)}</td>`;
+    }
+    html += '</tr>';
+    return html;
+  }
+
+  function bindEvents(): void {
+    const root = el.querySelector(`#${id}`) as HTMLElement;
+    if (!root) return;
+
+    root.querySelectorAll<HTMLElement>('.tx-pivot-group-row').forEach((row) => {
+      row.addEventListener('click', () => {
+        const group = row.getAttribute('data-group');
+        if (!group) return;
+        if (collapsed.has(group)) {
+          collapsed.delete(group);
+        } else {
+          collapsed.add(group);
+        }
+        render();
+        emit('pivot:toggle', { id, group, collapsed: collapsed.has(group) });
+      });
+    });
+  }
+
+  function loadData(data: Row[]): void {
+    currentData = data;
+    render();
+  }
+
+  // If source is a URL, fetch data
+  if (options.source.startsWith('[') || options.source.startsWith('{')) {
+    // Inline JSON
+    try {
+      loadData(JSON.parse(options.source));
+    } catch {
+      el.innerHTML = `<div class="${cls('tx-pivot', options.class)}" id="${esc(id)}"><p class="tx-pivot-empty">Invalid data</p></div>`;
+    }
+  } else if (options.source.startsWith('/') || options.source.startsWith('http')) {
+    el.innerHTML = `<div class="${cls('tx-pivot', options.class)}" id="${esc(id)}"><div class="tx-pivot-loading"><div class="tx-spinner"></div></div></div>`;
+    fetch(options.source)
+      .then((r) => r.json())
+      .then((data) => loadData(Array.isArray(data) ? data : data.data || []))
+      .catch(() => {
+        el.innerHTML = `<div class="${cls('tx-pivot', options.class)}" id="${esc(id)}"><p class="tx-pivot-empty">Failed to load data</p></div>`;
+      });
+  } else {
+    // Empty state
+    render();
+  }
+
+  return {
+    el: el.querySelector(`#${id}`) || el,
+    destroy() {
+      el.innerHTML = '';
+    },
+    refresh(data: Row[]) {
+      loadData(data);
+    },
+    getAggregatedData() {
+      const pivot = buildPivot(currentData, rowFields, colFields, valueFields);
+      const result: Record<string, unknown>[] = [];
+      for (const rk of pivot.rowKeys) {
+        const labels = pivot.rowLabels.get(rk)!;
+        const row: Record<string, unknown> = {};
+        rowFields.forEach((f, i) => {
+          row[f] = labels[i];
+        });
+        const rt = pivot.rowTotals.get(rk);
+        if (rt) {
+          for (const vf of valueFields) {
+            row[`${vf.field}_${vf.aggregate}`] = rt.get(vf.field) || 0;
+          }
+        }
+        result.push(row);
+      }
+      return result;
+    },
+  };
+}
+
+registerWidget('pivot-grid', (el, opts) => pivotGrid(el, opts as unknown as PivotOptions));
+export default pivotGrid;

--- a/styles/teryx.css
+++ b/styles/teryx.css
@@ -5645,3 +5645,91 @@ body.tx-lightbox-open {
   opacity: 0.85;
   flex-shrink: 0;
 }
+
+/* === Pivot Grid === */
+.tx-pivot {
+  font-family: var(--tx-font);
+  font-size: var(--tx-font-size);
+  overflow: auto;
+}
+.tx-pivot-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--tx-border);
+}
+.tx-pivot-table th,
+.tx-pivot-table td {
+  border: 1px solid var(--tx-border);
+  padding: var(--tx-space-2) var(--tx-space-3);
+  text-align: left;
+}
+.tx-pivot-corner {
+  background: var(--tx-bg-secondary);
+}
+.tx-pivot-header th {
+  background: var(--tx-bg-secondary);
+  font-weight: 600;
+  color: var(--tx-text);
+  white-space: nowrap;
+}
+.tx-pivot-col-header {
+  text-align: center !important;
+}
+.tx-pivot-value-field {
+  text-align: right !important;
+  font-size: 0.85em;
+}
+.tx-pivot-row-field {
+  font-weight: 600;
+}
+.tx-pivot-row-label {
+  color: var(--tx-text);
+}
+.tx-pivot-cell {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.tx-pivot-total,
+.tx-pivot-total-col,
+.tx-pivot-total-header {
+  background: color-mix(in srgb, var(--tx-primary) 6%, transparent);
+  font-weight: 600;
+}
+.tx-pivot-subtotal {
+  background: color-mix(in srgb, var(--tx-bg-secondary) 60%, transparent);
+  font-weight: 500;
+}
+.tx-pivot-grand-total-row td {
+  background: color-mix(in srgb, var(--tx-primary) 10%, transparent);
+  font-weight: 700;
+}
+.tx-pivot-grand-total-label {
+  text-align: left !important;
+}
+.tx-pivot-group-row {
+  cursor: pointer;
+  user-select: none;
+}
+.tx-pivot-group-row:hover td {
+  background: var(--tx-bg-secondary);
+}
+.tx-pivot-group-cell {
+  font-weight: 600;
+  color: var(--tx-text);
+}
+.tx-pivot-toggle {
+  font-size: 0.7em;
+  color: var(--tx-text-muted);
+}
+.tx-pivot-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--tx-space-8);
+}
+.tx-pivot-empty {
+  text-align: center;
+  padding: var(--tx-space-6);
+  color: var(--tx-text-muted);
+  font-style: italic;
+}

--- a/tests/browser/pivot-grid.spec.ts
+++ b/tests/browser/pivot-grid.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, count } from './helpers';
+
+const SALES_DATA = [
+  { region: 'North', product: 'Widget', quarter: 'Q1', revenue: 100, units: 10 },
+  { region: 'North', product: 'Widget', quarter: 'Q2', revenue: 150, units: 15 },
+  { region: 'North', product: 'Gadget', quarter: 'Q1', revenue: 200, units: 20 },
+  { region: 'South', product: 'Widget', quarter: 'Q1', revenue: 120, units: 12 },
+  { region: 'South', product: 'Widget', quarter: 'Q2', revenue: 180, units: 18 },
+  { region: 'South', product: 'Gadget', quarter: 'Q1', revenue: 90, units: 9 },
+  { region: 'South', product: 'Gadget', quarter: 'Q2', revenue: 110, units: 11 },
+];
+
+test.describe('PivotGrid Widget', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+  });
+
+  test('renders a pivot table', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    await expect(page.locator('.tx-pivot-table')).toBeVisible();
+  });
+
+  test('renders row labels', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    await expect(page.locator('.tx-pivot-row-label').filter({ hasText: 'North' })).toBeVisible();
+    await expect(page.locator('.tx-pivot-row-label').filter({ hasText: 'South' })).toBeVisible();
+  });
+
+  test('computes correct sum aggregates', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    const firstCell = await page
+      .locator('.tx-pivot-data-row .tx-pivot-cell:not(.tx-pivot-total)')
+      .first()
+      .textContent();
+    expect(Number(firstCell)).toBe(450);
+  });
+
+  test('renders column headers', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: ['quarter'],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    await expect(page.locator('.tx-pivot-col-header').filter({ hasText: 'Q1' })).toBeVisible();
+    await expect(page.locator('.tx-pivot-col-header').filter({ hasText: 'Q2' })).toBeVisible();
+  });
+
+  test('renders grand total row', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    await expect(page.locator('.tx-pivot-grand-total-row')).toContainText('Grand Total');
+    const grandCell = await page.locator('.tx-pivot-grand-total').first().textContent();
+    expect(Number(grandCell)).toBe(950);
+  });
+
+  test('expandable groups with multiple row fields', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region', 'product'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    const groups = await count(page, '.tx-pivot-group-row');
+    expect(groups).toBe(2);
+    const dataRows = await count(page, '.tx-pivot-data-row');
+    expect(dataRows).toBeGreaterThan(0);
+  });
+
+  test('clicking group row collapses detail rows', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region', 'product'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    const initialRows = await count(page, '.tx-pivot-data-row');
+    await page.locator('.tx-pivot-group-row').first().click();
+    await page.waitForTimeout(100);
+    const afterRows = await count(page, '.tx-pivot-data-row');
+    expect(afterRows).toBeLessThan(initialRows);
+  });
+
+  test('refresh updates with new data', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).__pv = (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    await page.evaluate(() => {
+      (window as any).__pv.refresh([
+        { region: 'East', revenue: 300 },
+        { region: 'West', revenue: 400 },
+      ]);
+    });
+    await page.waitForTimeout(100);
+    await expect(page.locator('.tx-pivot-row-label').filter({ hasText: 'East' })).toBeVisible();
+    await expect(page.locator('.tx-pivot-row-label').filter({ hasText: 'West' })).toBeVisible();
+  });
+
+  test('getAggregatedData returns results', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).__pv = (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    const result = await page.evaluate(() => (window as any).__pv.getAggregatedData());
+    expect(result.length).toBe(2);
+    const north = result.find((d: Record<string, unknown>) => d.region === 'North');
+    expect(north.revenue_sum).toBe(450);
+  });
+
+  test('destroy clears the widget', async ({ page }) => {
+    await page.evaluate((data) => {
+      (window as any).__pv = (window as any).Teryx.pivotGrid('#target', {
+        source: JSON.stringify(data),
+        rows: ['region'],
+        columns: [],
+        values: [{ field: 'revenue', aggregate: 'sum' }],
+      });
+    }, SALES_DATA);
+    await expect(page.locator('.tx-pivot-table')).toBeVisible();
+    await page.evaluate(() => (window as any).__pv.destroy());
+    await page.waitForTimeout(100);
+    const tables = await count(page, '.tx-pivot-table');
+    expect(tables).toBe(0);
+  });
+});

--- a/tests/widgets/pivot-grid.test.ts
+++ b/tests/widgets/pivot-grid.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { pivotGrid } from '../../src/widgets/pivot-grid';
+
+const SALES_DATA = [
+  { region: 'North', product: 'Widget', quarter: 'Q1', revenue: 100, units: 10 },
+  { region: 'North', product: 'Widget', quarter: 'Q2', revenue: 150, units: 15 },
+  { region: 'North', product: 'Gadget', quarter: 'Q1', revenue: 200, units: 20 },
+  { region: 'South', product: 'Widget', quarter: 'Q1', revenue: 120, units: 12 },
+  { region: 'South', product: 'Widget', quarter: 'Q2', revenue: 180, units: 18 },
+  { region: 'South', product: 'Gadget', quarter: 'Q1', revenue: 90, units: 9 },
+  { region: 'South', product: 'Gadget', quarter: 'Q2', revenue: 110, units: 11 },
+];
+
+describe('PivotGrid widget', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should render a pivot table', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    expect(container.querySelector('.tx-pivot-table')).not.toBeNull();
+  });
+
+  it('should render row labels', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const labels = container.querySelectorAll('.tx-pivot-row-label');
+    const texts = Array.from(labels).map((l) => l.textContent);
+    expect(texts).toContain('North');
+    expect(texts).toContain('South');
+  });
+
+  it('should compute sum aggregate', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const cells = container.querySelectorAll('.tx-pivot-data-row .tx-pivot-cell:not(.tx-pivot-total)');
+    const northRevenue = Number(cells[0].textContent);
+    expect(northRevenue).toBe(450); // 100+150+200
+  });
+
+  it('should compute count aggregate', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'count' }],
+    });
+    const cells = container.querySelectorAll('.tx-pivot-data-row .tx-pivot-cell:not(.tx-pivot-total)');
+    const northCount = Number(cells[0].textContent);
+    expect(northCount).toBe(3);
+  });
+
+  it('should compute avg aggregate', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'avg' }],
+    });
+    const cells = container.querySelectorAll('.tx-pivot-data-row .tx-pivot-cell:not(.tx-pivot-total)');
+    const northAvg = Number(cells[0].textContent);
+    expect(northAvg).toBe(150); // (100+150+200)/3
+  });
+
+  it('should compute min aggregate', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'min' }],
+    });
+    const cells = container.querySelectorAll('.tx-pivot-data-row .tx-pivot-cell:not(.tx-pivot-total)');
+    expect(Number(cells[0].textContent)).toBe(100);
+  });
+
+  it('should compute max aggregate', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'max' }],
+    });
+    const cells = container.querySelectorAll('.tx-pivot-data-row .tx-pivot-cell:not(.tx-pivot-total)');
+    expect(Number(cells[0].textContent)).toBe(200);
+  });
+
+  it('should render column headers when column fields provided', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: ['quarter'],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const colHeaders = container.querySelectorAll('.tx-pivot-col-header');
+    expect(colHeaders.length).toBeGreaterThan(0);
+    const texts = Array.from(colHeaders).map((h) => h.textContent);
+    expect(texts).toContain('Q1');
+    expect(texts).toContain('Q2');
+  });
+
+  it('should render grand total row', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const grandTotal = container.querySelector('.tx-pivot-grand-total-row');
+    expect(grandTotal).not.toBeNull();
+    expect(grandTotal!.textContent).toContain('Grand Total');
+  });
+
+  it('should render grand total with correct value', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const grandCells = container.querySelectorAll('.tx-pivot-grand-total');
+    const total = Number(grandCells[0].textContent);
+    expect(total).toBe(950); // sum of all revenue
+  });
+
+  it('should support multiple row fields', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region', 'product'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const groupRows = container.querySelectorAll('.tx-pivot-group-row');
+    expect(groupRows.length).toBe(2); // North, South
+  });
+
+  it('should toggle group collapse on click', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region', 'product'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const initialDataRows = container.querySelectorAll('.tx-pivot-data-row').length;
+    const groupRow = container.querySelector('.tx-pivot-group-row') as HTMLElement;
+    groupRow.click();
+    const afterCollapseRows = container.querySelectorAll('.tx-pivot-data-row').length;
+    expect(afterCollapseRows).toBeLessThan(initialDataRows);
+  });
+
+  it('should support multiple value fields', () => {
+    pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [
+        { field: 'revenue', aggregate: 'sum' },
+        { field: 'units', aggregate: 'sum' },
+      ],
+    });
+    const valueHeaders = container.querySelectorAll('.tx-pivot-value-field');
+    expect(valueHeaders.length).toBeGreaterThanOrEqual(4); // 2 value + 2 total cols
+  });
+
+  it('refresh() updates with new data', () => {
+    const p = pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    p.refresh([
+      { region: 'East', revenue: 300 },
+      { region: 'West', revenue: 400 },
+    ]);
+    const labels = container.querySelectorAll('.tx-pivot-row-label');
+    const texts = Array.from(labels).map((l) => l.textContent);
+    expect(texts).toContain('East');
+    expect(texts).toContain('West');
+    expect(texts).not.toContain('North');
+  });
+
+  it('getAggregatedData() returns pivot results', () => {
+    const p = pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    const data = p.getAggregatedData();
+    expect(data.length).toBe(2);
+    const north = data.find((d) => d.region === 'North');
+    expect(north).toBeDefined();
+    expect(north!.revenue_sum).toBe(450);
+  });
+
+  it('destroy() clears content', () => {
+    const p = pivotGrid(container, {
+      source: JSON.stringify(SALES_DATA),
+      rows: ['region'],
+      columns: [],
+      values: [{ field: 'revenue', aggregate: 'sum' }],
+    });
+    p.destroy();
+    expect(container.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Pivot Grid widget with row/column aggregation
- Supports sum, avg, count, min, max aggregate functions
- Features grand totals, column totals, row totals, expandable groups
- Provides programmatic API: `refresh()`, `getAggregatedData()`
- Includes CSS styles, 16 unit tests, and 10 browser tests

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `pnpm test` — 613 unit tests pass (16 new pivot tests)
- [x] `pnpm test:browser` — 388 browser tests pass (10 new pivot tests)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check` passes

Closes #11