### PR TITLE
Implement Kanban Board widget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ export {
   tagInput,
   datePicker,
   transferList,
+  kanban,
 } from './widgets';
 
 // Category imports

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -40,3 +40,4 @@ export { draggable, droppable } from './drag-drop';
 export { slider } from './slider';
 export { tagInput } from './tag-input';
 export { transferList } from './transfer-list';
+export { kanban } from './kanban';

--- a/src/widgets/kanban.ts
+++ b/src/widgets/kanban.ts
@@ -1,0 +1,237 @@
+// ============================================================
+// Teryx — Kanban Board Widget
+// ============================================================
+
+import type { KanbanOptions, KanbanCard, KanbanColumn, WidgetInstance } from '../types';
+import { uid, esc, cls, icon, resolveTarget } from '../utils';
+import { registerWidget, emit } from '../core';
+import { draggable, droppable } from './drag-drop';
+import type { DraggableInstance, DroppableInstance } from './drag-drop';
+
+export interface KanbanInstance extends WidgetInstance {
+  getColumns(): KanbanColumn[];
+  addCard(columnId: string, card: KanbanCard): void;
+  removeCard(cardId: string): void;
+  moveCard(cardId: string, toColumnId: string): void;
+}
+
+export function kanban(target: string | HTMLElement, options: KanbanOptions): KanbanInstance {
+  const el = resolveTarget(target);
+  const id = options.id || uid('tx-kanban');
+  const isDraggable = options.draggable !== false;
+
+  // Deep-copy columns so mutations don't affect caller
+  const columns: KanbanColumn[] = JSON.parse(JSON.stringify(options.columns));
+
+  const dragInstances: DraggableInstance[] = [];
+  const dropInstances: DroppableInstance[] = [];
+
+  function findCard(cardId: string): { card: KanbanCard; column: KanbanColumn } | null {
+    for (const col of columns) {
+      const card = col.items?.find((c) => c.id === cardId);
+      if (card) return { card, column: col };
+    }
+    return null;
+  }
+
+  function renderCard(card: KanbanCard): string {
+    if (options.cardTemplate) {
+      return options.cardTemplate
+        .replace(/\{\{id\}\}/g, esc(card.id))
+        .replace(/\{\{title\}\}/g, esc(card.title))
+        .replace(/\{\{description\}\}/g, esc(card.description || ''))
+        .replace(/\{\{assignee\}\}/g, esc(card.assignee || ''))
+        .replace(/\{\{priority\}\}/g, esc(card.priority || ''));
+    }
+
+    let html = `<div class="${cls('tx-kanban-card', card.priority && `tx-kanban-card-${card.priority}`)}" data-card-id="${esc(card.id)}">`;
+    html += `<div class="tx-kanban-card-title">${esc(card.title)}</div>`;
+
+    if (card.description) {
+      html += `<div class="tx-kanban-card-desc">${esc(card.description)}</div>`;
+    }
+
+    if (card.labels && card.labels.length > 0) {
+      html += '<div class="tx-kanban-card-labels">';
+      for (const label of card.labels) {
+        html += `<span class="tx-kanban-card-label">${esc(label)}</span>`;
+      }
+      html += '</div>';
+    }
+
+    const hasFooter = card.assignee || card.priority;
+    if (hasFooter) {
+      html += '<div class="tx-kanban-card-footer">';
+      if (card.assignee) {
+        html += `<span class="tx-kanban-card-assignee">${icon('user')} ${esc(card.assignee)}</span>`;
+      }
+      if (card.priority) {
+        html += `<span class="tx-kanban-card-priority tx-kanban-priority-${esc(card.priority)}">${esc(card.priority)}</span>`;
+      }
+      html += '</div>';
+    }
+
+    html += '</div>';
+    return html;
+  }
+
+  function renderColumn(col: KanbanColumn): string {
+    const items = col.items || [];
+    const isOverLimit = col.limit !== undefined && items.length > col.limit;
+
+    let html = `<div class="${cls('tx-kanban-column', isOverLimit && 'tx-kanban-column-over-limit')}" data-column-id="${esc(col.id)}">`;
+
+    html += '<div class="tx-kanban-column-header"';
+    if (col.color) html += ` style="border-top: 3px solid ${esc(col.color)}"`;
+    html += '>';
+    html += `<span class="tx-kanban-column-title">${esc(col.title)}</span>`;
+    html += `<span class="tx-kanban-column-count">${items.length}`;
+    if (col.limit !== undefined) {
+      html += ` / ${col.limit}`;
+    }
+    html += '</span>';
+    html += '</div>';
+
+    html += '<div class="tx-kanban-column-body">';
+    for (const card of items) {
+      html += renderCard(card);
+    }
+    if (items.length === 0) {
+      html += '<div class="tx-kanban-empty">No items</div>';
+    }
+    html += '</div>';
+
+    html += '</div>';
+    return html;
+  }
+
+  function destroyDragDrop(): void {
+    for (const inst of dragInstances) inst.destroy();
+    for (const inst of dropInstances) inst.destroy();
+    dragInstances.length = 0;
+    dropInstances.length = 0;
+  }
+
+  function setupDragDrop(): void {
+    if (!isDraggable) return;
+    const root = el.querySelector(`#${id}`) as HTMLElement;
+    if (!root) return;
+
+    root.querySelectorAll<HTMLElement>('.tx-kanban-card').forEach((cardEl) => {
+      const cardId = cardEl.getAttribute('data-card-id')!;
+      const colEl = cardEl.closest('.tx-kanban-column') as HTMLElement;
+      const colId = colEl?.getAttribute('data-column-id') || '';
+      dragInstances.push(
+        draggable(cardEl, {
+          data: { cardId, fromCol: colId },
+          ghost: true,
+        }),
+      );
+    });
+
+    root.querySelectorAll<HTMLElement>('.tx-kanban-column-body').forEach((bodyEl) => {
+      const colEl = bodyEl.closest('.tx-kanban-column') as HTMLElement;
+      const colId = colEl?.getAttribute('data-column-id') || '';
+      dropInstances.push(
+        droppable(bodyEl, {
+          hoverClass: 'tx-kanban-drop-hover',
+          accept: (data: unknown) => {
+            const d = data as { cardId: string; fromCol: string };
+            return d.fromCol !== colId;
+          },
+          onDrop: (_dropEl: HTMLElement, data: unknown) => {
+            const d = data as { cardId: string; fromCol: string };
+            doMove(d.cardId, d.fromCol, colId);
+          },
+        }),
+      );
+    });
+  }
+
+  function doMove(cardId: string, fromColId: string, toColId: string): void {
+    const fromCol = columns.find((c) => c.id === fromColId);
+    const toCol = columns.find((c) => c.id === toColId);
+    if (!fromCol || !toCol || !fromCol.items) return;
+
+    const idx = fromCol.items.findIndex((c) => c.id === cardId);
+    if (idx === -1) return;
+
+    const [card] = fromCol.items.splice(idx, 1);
+    if (!toCol.items) toCol.items = [];
+    toCol.items.push(card);
+
+    options.onMove?.(cardId, fromColId, toColId);
+    emit('kanban:move', { id, cardId, fromCol: fromColId, toCol: toColId });
+    render();
+  }
+
+  function bindEvents(): void {
+    const root = el.querySelector(`#${id}`) as HTMLElement;
+    if (!root) return;
+
+    root.addEventListener('click', (e) => {
+      const cardEl = (e.target as HTMLElement).closest('.tx-kanban-card') as HTMLElement;
+      if (!cardEl) return;
+      const cardId = cardEl.getAttribute('data-card-id');
+      if (!cardId) return;
+      const found = findCard(cardId);
+      if (found && options.onCardClick) {
+        options.onCardClick(found.card);
+      }
+      emit('kanban:cardclick', { id, card: found?.card });
+    });
+  }
+
+  function render(): void {
+    destroyDragDrop();
+
+    let html = `<div class="${cls('tx-kanban', options.class)}" id="${esc(id)}">`;
+    for (const col of columns) {
+      html += renderColumn(col);
+    }
+    html += '</div>';
+    el.innerHTML = html;
+
+    bindEvents();
+    requestAnimationFrame(() => setupDragDrop());
+  }
+
+  render();
+
+  return {
+    el: el.querySelector(`#${id}`) || el,
+    destroy() {
+      destroyDragDrop();
+      el.innerHTML = '';
+    },
+    getColumns() {
+      return JSON.parse(JSON.stringify(columns));
+    },
+    addCard(columnId: string, card: KanbanCard) {
+      const col = columns.find((c) => c.id === columnId);
+      if (!col) return;
+      if (!col.items) col.items = [];
+      col.items.push(JSON.parse(JSON.stringify(card)));
+      render();
+    },
+    removeCard(cardId: string) {
+      for (const col of columns) {
+        if (!col.items) continue;
+        const idx = col.items.findIndex((c) => c.id === cardId);
+        if (idx !== -1) {
+          col.items.splice(idx, 1);
+          render();
+          return;
+        }
+      }
+    },
+    moveCard(cardId: string, toColumnId: string) {
+      const found = findCard(cardId);
+      if (!found) return;
+      doMove(cardId, found.column.id, toColumnId);
+    },
+  };
+}
+
+registerWidget('kanban', (el, opts) => kanban(el, opts as unknown as KanbanOptions));
+export default kanban;

--- a/styles/teryx.css
+++ b/styles/teryx.css
@@ -5378,3 +5378,139 @@ body.tx-drawer-open {
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* === Kanban Board === */
+.tx-kanban {
+  display: flex;
+  gap: var(--tx-space-4);
+  font-family: var(--tx-font);
+  font-size: var(--tx-font-size);
+  overflow-x: auto;
+  padding: var(--tx-space-2) 0;
+}
+.tx-kanban-column {
+  flex: 1;
+  min-width: 260px;
+  max-width: 360px;
+  background: var(--tx-bg-secondary);
+  border-radius: var(--tx-radius-lg);
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+}
+.tx-kanban-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--tx-space-3) var(--tx-space-4);
+  border-bottom: 1px solid var(--tx-border);
+  font-weight: 600;
+}
+.tx-kanban-column-title {
+  color: var(--tx-text);
+}
+.tx-kanban-column-count {
+  font-size: 0.8em;
+  color: var(--tx-text-muted);
+  background: var(--tx-bg);
+  padding: var(--tx-space-1) var(--tx-space-2);
+  border-radius: var(--tx-radius-sm);
+}
+.tx-kanban-column-over-limit .tx-kanban-column-count {
+  background: color-mix(in srgb, var(--tx-danger) 15%, transparent);
+  color: var(--tx-danger);
+}
+.tx-kanban-column-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--tx-space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--tx-space-2);
+  min-height: 60px;
+}
+.tx-kanban-card {
+  background: var(--tx-bg);
+  border: 1px solid var(--tx-border);
+  border-radius: var(--tx-radius);
+  padding: var(--tx-space-3);
+  cursor: pointer;
+  transition:
+    box-shadow var(--tx-transition),
+    border-color var(--tx-transition);
+}
+.tx-kanban-card:hover {
+  box-shadow: var(--tx-shadow-sm);
+  border-color: var(--tx-border-strong);
+}
+.tx-kanban-card-title {
+  font-weight: 600;
+  color: var(--tx-text);
+  margin-bottom: var(--tx-space-1);
+}
+.tx-kanban-card-desc {
+  font-size: 0.9em;
+  color: var(--tx-text-secondary);
+  margin-bottom: var(--tx-space-2);
+}
+.tx-kanban-card-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--tx-space-1);
+  margin-bottom: var(--tx-space-2);
+}
+.tx-kanban-card-label {
+  font-size: 0.75em;
+  padding: 1px var(--tx-space-2);
+  border-radius: var(--tx-radius-sm);
+  background: color-mix(in srgb, var(--tx-primary) 15%, transparent);
+  color: var(--tx-primary);
+}
+.tx-kanban-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.8em;
+  color: var(--tx-text-muted);
+}
+.tx-kanban-card-assignee {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tx-space-1);
+}
+.tx-kanban-card-priority {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.tx-kanban-priority-high {
+  color: var(--tx-danger);
+}
+.tx-kanban-priority-medium {
+  color: var(--tx-warning);
+}
+.tx-kanban-priority-low {
+  color: var(--tx-success);
+}
+.tx-kanban-card-high {
+  border-left: 3px solid var(--tx-danger);
+}
+.tx-kanban-card-medium {
+  border-left: 3px solid var(--tx-warning);
+}
+.tx-kanban-card-low {
+  border-left: 3px solid var(--tx-success);
+}
+.tx-kanban-drop-hover {
+  background: color-mix(in srgb, var(--tx-primary) 8%, transparent);
+  outline: 2px dashed var(--tx-primary);
+  outline-offset: -2px;
+  border-radius: var(--tx-radius);
+}
+.tx-kanban-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--tx-space-6);
+  color: var(--tx-text-muted);
+  font-style: italic;
+}

--- a/tests/browser/kanban.spec.ts
+++ b/tests/browser/kanban.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test';
+import { setupPage, count } from './helpers';
+
+const COLUMNS = [
+  {
+    id: 'todo',
+    title: 'To Do',
+    items: [
+      { id: 'c1', title: 'Task 1', description: 'First task' },
+      { id: 'c2', title: 'Task 2', labels: ['bug'], priority: 'high' },
+    ],
+  },
+  {
+    id: 'doing',
+    title: 'In Progress',
+    items: [{ id: 'c3', title: 'Task 3', assignee: 'Alice' }],
+  },
+  { id: 'done', title: 'Done', items: [] },
+];
+
+test.describe('Kanban Board Widget', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+  });
+
+  test('renders columns with titles', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    const colCount = await count(page, '.tx-kanban-column');
+    expect(colCount).toBe(3);
+    await expect(page.locator('.tx-kanban-column-title').nth(0)).toHaveText('To Do');
+    await expect(page.locator('.tx-kanban-column-title').nth(1)).toHaveText('In Progress');
+    await expect(page.locator('.tx-kanban-column-title').nth(2)).toHaveText('Done');
+  });
+
+  test('renders cards in correct columns', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    const todoCards = await count(page, '[data-column-id="todo"] .tx-kanban-card');
+    const doingCards = await count(page, '[data-column-id="doing"] .tx-kanban-card');
+    const doneCards = await count(page, '[data-column-id="done"] .tx-kanban-card');
+    expect(todoCards).toBe(2);
+    expect(doingCards).toBe(1);
+    expect(doneCards).toBe(0);
+  });
+
+  test('renders card content', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    const card = page.locator('[data-card-id="c1"]');
+    await expect(card.locator('.tx-kanban-card-title')).toHaveText('Task 1');
+    await expect(card.locator('.tx-kanban-card-desc')).toHaveText('First task');
+  });
+
+  test('renders card labels', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    const labels = await count(page, '[data-card-id="c2"] .tx-kanban-card-label');
+    expect(labels).toBe(1);
+    await expect(page.locator('[data-card-id="c2"] .tx-kanban-card-label').first()).toHaveText('bug');
+  });
+
+  test('renders card assignee and priority', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    await expect(page.locator('[data-card-id="c3"] .tx-kanban-card-assignee')).toContainText('Alice');
+    await expect(page.locator('[data-card-id="c2"] .tx-kanban-card-priority')).toHaveText('high');
+  });
+
+  test('shows column counts', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    await expect(page.locator('.tx-kanban-column-count').nth(0)).toHaveText('2');
+    await expect(page.locator('.tx-kanban-column-count').nth(1)).toHaveText('1');
+    await expect(page.locator('.tx-kanban-column-count').nth(2)).toHaveText('0');
+  });
+
+  test('shows WIP limit and over-limit class', async ({ page }) => {
+    const cols = JSON.parse(JSON.stringify(COLUMNS));
+    cols[0].limit = 1;
+    await page.evaluate((c) => {
+      (window as any).Teryx.kanban('#target', { columns: c });
+    }, cols);
+    await expect(page.locator('[data-column-id="todo"] .tx-kanban-column-count')).toHaveText('2 / 1');
+    await expect(page.locator('[data-column-id="todo"]')).toHaveClass(/tx-kanban-column-over-limit/);
+  });
+
+  test('shows empty message in empty column', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    await expect(page.locator('[data-column-id="done"] .tx-kanban-empty')).toHaveText('No items');
+  });
+
+  test('addCard adds a card to a column', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).__kb = (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    await page.evaluate(() => {
+      (window as any).__kb.addCard('done', { id: 'c4', title: 'Task 4' });
+    });
+    await page.waitForTimeout(100);
+    const doneCards = await count(page, '[data-column-id="done"] .tx-kanban-card');
+    expect(doneCards).toBe(1);
+    await expect(page.locator('[data-card-id="c4"] .tx-kanban-card-title')).toHaveText('Task 4');
+  });
+
+  test('removeCard removes a card', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).__kb = (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    await page.evaluate(() => {
+      (window as any).__kb.removeCard('c1');
+    });
+    await page.waitForTimeout(100);
+    const todoCards = await count(page, '[data-column-id="todo"] .tx-kanban-card');
+    expect(todoCards).toBe(1);
+  });
+
+  test('moveCard moves a card between columns', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).__kb = (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    await page.evaluate(() => {
+      (window as any).__kb.moveCard('c1', 'doing');
+    });
+    await page.waitForTimeout(100);
+    const todoCards = await count(page, '[data-column-id="todo"] .tx-kanban-card');
+    const doingCards = await count(page, '[data-column-id="doing"] .tx-kanban-card');
+    expect(todoCards).toBe(1);
+    expect(doingCards).toBe(2);
+  });
+
+  test('getColumns returns current state', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).__kb = (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    const colData = await page.evaluate(() => (window as any).__kb.getColumns());
+    expect(colData.length).toBe(3);
+    expect(colData[0].items.length).toBe(2);
+    expect(colData[1].items.length).toBe(1);
+  });
+
+  test('destroy clears the widget', async ({ page }) => {
+    await page.evaluate((cols) => {
+      (window as any).__kb = (window as any).Teryx.kanban('#target', { columns: cols });
+    }, COLUMNS);
+    await expect(page.locator('.tx-kanban')).toBeVisible();
+    await page.evaluate(() => (window as any).__kb.destroy());
+    await page.waitForTimeout(100);
+    const boards = await count(page, '.tx-kanban');
+    expect(boards).toBe(0);
+  });
+});

--- a/tests/widgets/kanban.test.ts
+++ b/tests/widgets/kanban.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { kanban } from '../../src/widgets/kanban';
+
+const COLUMNS = [
+  {
+    id: 'todo',
+    title: 'To Do',
+    items: [
+      { id: 'c1', title: 'Task 1', description: 'First task' },
+      { id: 'c2', title: 'Task 2', labels: ['bug'], priority: 'high' },
+    ],
+  },
+  {
+    id: 'doing',
+    title: 'In Progress',
+    items: [{ id: 'c3', title: 'Task 3', assignee: 'Alice' }],
+  },
+  {
+    id: 'done',
+    title: 'Done',
+    items: [],
+  },
+];
+
+function deepCopy<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+describe('Kanban widget', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should render columns', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const cols = container.querySelectorAll('.tx-kanban-column');
+    expect(cols.length).toBe(3);
+  });
+
+  it('should render column titles', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const titles = container.querySelectorAll('.tx-kanban-column-title');
+    expect(titles[0].textContent).toBe('To Do');
+    expect(titles[1].textContent).toBe('In Progress');
+    expect(titles[2].textContent).toBe('Done');
+  });
+
+  it('should render cards within columns', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const todoCards = container.querySelector('[data-column-id="todo"]')!.querySelectorAll('.tx-kanban-card');
+    expect(todoCards.length).toBe(2);
+    const doingCards = container.querySelector('[data-column-id="doing"]')!.querySelectorAll('.tx-kanban-card');
+    expect(doingCards.length).toBe(1);
+  });
+
+  it('should render card title and description', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const card = container.querySelector('[data-card-id="c1"]')!;
+    expect(card.querySelector('.tx-kanban-card-title')!.textContent).toBe('Task 1');
+    expect(card.querySelector('.tx-kanban-card-desc')!.textContent).toBe('First task');
+  });
+
+  it('should render card labels', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const card = container.querySelector('[data-card-id="c2"]')!;
+    const labels = card.querySelectorAll('.tx-kanban-card-label');
+    expect(labels.length).toBe(1);
+    expect(labels[0].textContent).toBe('bug');
+  });
+
+  it('should render card assignee', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const card = container.querySelector('[data-card-id="c3"]')!;
+    expect(card.querySelector('.tx-kanban-card-assignee')!.textContent).toContain('Alice');
+  });
+
+  it('should render card priority', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const card = container.querySelector('[data-card-id="c2"]')!;
+    expect(card.querySelector('.tx-kanban-card-priority')!.textContent).toBe('high');
+    expect(card.classList.contains('tx-kanban-card-high')).toBe(true);
+  });
+
+  it('should show column count', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const counts = container.querySelectorAll('.tx-kanban-column-count');
+    expect(counts[0].textContent).toBe('2');
+    expect(counts[1].textContent).toBe('1');
+    expect(counts[2].textContent).toBe('0');
+  });
+
+  it('should show WIP limit in column count', () => {
+    const cols = deepCopy(COLUMNS);
+    cols[0].limit = 3;
+    kanban(container, { columns: cols });
+    const count = container.querySelector('[data-column-id="todo"] .tx-kanban-column-count')!;
+    expect(count.textContent).toBe('2 / 3');
+  });
+
+  it('should add over-limit class when column exceeds limit', () => {
+    const cols = deepCopy(COLUMNS);
+    cols[0].limit = 1;
+    kanban(container, { columns: cols });
+    const col = container.querySelector('[data-column-id="todo"]')!;
+    expect(col.classList.contains('tx-kanban-column-over-limit')).toBe(true);
+  });
+
+  it('should show empty message for empty columns', () => {
+    kanban(container, { columns: deepCopy(COLUMNS) });
+    const empty = container.querySelector('[data-column-id="done"] .tx-kanban-empty');
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe('No items');
+  });
+
+  it('should apply column color as header border', () => {
+    const cols = deepCopy(COLUMNS);
+    cols[0].color = '#ff0000';
+    kanban(container, { columns: cols });
+    const header = container.querySelector('[data-column-id="todo"] .tx-kanban-column-header') as HTMLElement;
+    expect(header.style.borderTop).toContain('rgb(255, 0, 0)');
+  });
+
+  it('getColumns() returns deep copy of columns', () => {
+    const k = kanban(container, { columns: deepCopy(COLUMNS) });
+    const cols = k.getColumns();
+    expect(cols.length).toBe(3);
+    expect(cols[0].items!.length).toBe(2);
+    // Mutation shouldn't affect the widget
+    cols[0].items!.push({ id: 'x', title: 'X' });
+    expect(k.getColumns()[0].items!.length).toBe(2);
+  });
+
+  it('addCard() adds a card to a column', () => {
+    const k = kanban(container, { columns: deepCopy(COLUMNS) });
+    k.addCard('done', { id: 'c4', title: 'Task 4' });
+    const doneCards = container.querySelector('[data-column-id="done"]')!.querySelectorAll('.tx-kanban-card');
+    expect(doneCards.length).toBe(1);
+    expect(k.getColumns()[2].items!.length).toBe(1);
+  });
+
+  it('removeCard() removes a card', () => {
+    const k = kanban(container, { columns: deepCopy(COLUMNS) });
+    k.removeCard('c1');
+    const todoCards = container.querySelector('[data-column-id="todo"]')!.querySelectorAll('.tx-kanban-card');
+    expect(todoCards.length).toBe(1);
+    expect(k.getColumns()[0].items!.length).toBe(1);
+  });
+
+  it('moveCard() moves a card between columns', () => {
+    const onMove = vi.fn();
+    const k = kanban(container, { columns: deepCopy(COLUMNS), onMove });
+    k.moveCard('c1', 'doing');
+    expect(onMove).toHaveBeenCalledWith('c1', 'todo', 'doing');
+    expect(k.getColumns()[0].items!.length).toBe(1);
+    expect(k.getColumns()[1].items!.length).toBe(2);
+  });
+
+  it('onCardClick fires when a card is clicked', () => {
+    const onCardClick = vi.fn();
+    kanban(container, { columns: deepCopy(COLUMNS), onCardClick });
+    const cardEl = container.querySelector('[data-card-id="c1"]') as HTMLElement;
+    cardEl.click();
+    expect(onCardClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'c1', title: 'Task 1' }));
+  });
+
+  it('should use custom cardTemplate when provided', () => {
+    kanban(container, {
+      columns: deepCopy(COLUMNS),
+      cardTemplate: '<div class="custom-card" data-card-id="{{id}}"><b>{{title}}</b></div>',
+    });
+    const customs = container.querySelectorAll('.custom-card');
+    expect(customs.length).toBe(3);
+    expect(customs[0].querySelector('b')!.textContent).toBe('Task 1');
+  });
+
+  it('destroy() clears content', () => {
+    const k = kanban(container, { columns: deepCopy(COLUMNS) });
+    k.destroy();
+    expect(container.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Kanban Board widget with drag-and-drop card management across columns
- Supports column colors, WIP limits, card priorities, labels, assignees, and custom card templates
- Provides programmatic API: `addCard()`, `removeCard()`, `moveCard()`, `getColumns()`
- Includes CSS styles, 19 unit tests, and 13 browser tests

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `pnpm test` — 560 unit tests pass (19 new kanban tests)
- [x] `pnpm test:browser` — 353 browser tests pass (13 new kanban tests)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check` passes

Closes #1