### PR TITLE
Bump xhtmlx version string to 0.3.0

### DIFF
--- a/xhtmlx.js
+++ b/xhtmlx.js
@@ -2345,7 +2345,7 @@
     },
 
     /** Internal version string */
-    version: "0.2.0",
+    version: "0.3.0",
 
     // --- Internals exposed for testing (not part of the public API) ----------
     _internals: {


### PR DESCRIPTION
## Summary
- Update the internal version string in `xhtmlx.js` from `"0.2.0"` to `"0.3.0"` to match the project release

## Test plan
- [x] All 613 unit tests pass
- [x] Build succeeds
- [x] Lint passes (0 errors)