### PR TITLE
Remove scrollbar track from tabs nav bar

### DIFF
--- a/styles/teryx.css
+++ b/styles/teryx.css
@@ -1249,7 +1249,6 @@ body.tx-modal-open {
 .tx-tabs-nav {
   display: flex;
   border-bottom: 2px solid var(--tx-border);
-  overflow-x: auto;
 }
 .tx-tabs-nav-inner {
   display: flex;
@@ -1373,6 +1372,9 @@ body.tx-modal-open {
 }
 
 /* Scrollable */
+.tx-tabs-scrollable .tx-tabs-nav {
+  overflow-x: auto;
+}
 .tx-tabs-scrollable {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- `overflow-x: auto` on `.tx-tabs-nav` caused Chrome to render a visible scrollbar track (gray bar) below the tab buttons even when content didn't overflow
- Moved `overflow-x: auto` to only apply under `.tx-tabs-scrollable .tx-tabs-nav`

## Test plan
- [x] All 613 unit tests pass
- [x] CI passes